### PR TITLE
Add feature to filter videos by date

### DIFF
--- a/youtube2zim/entrypoint.py
+++ b/youtube2zim/entrypoint.py
@@ -181,7 +181,7 @@ def main():
         scraper = Youtube2Zim(**dict(args._get_kwargs()), youtube_store=YOUTUBE)
         scraper.run()
     except Exception as exc:
-        logger.error(f"FAILED. An error occured: {exc}")
+        logger.error(f"FAILED. An error occurred: {exc}")
         if args.debug:
             logger.exception(exc)
         raise SystemExit(1)

--- a/youtube2zim/entrypoint.py
+++ b/youtube2zim/entrypoint.py
@@ -167,6 +167,10 @@ def main():
         action="version",
         version=SCRAPER,
     )
+    parser.add_argument(
+        "--dateafter",
+        help="Custom filter to download videos uploaded on or after specified date. Format: YYYYMMDD or (now|today)[+-][0-9](day|week|month|year)(s)?"
+    )
 
     args = parser.parse_args()
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -272,7 +272,7 @@ class Youtube2Zim(object):
         logger.info("compute list of videos")
         self.extract_videos_list()
         logger.info(".. {} videos.".format(len(self.videos_ids)))
-        logger.info(f"videos in date range: {self.dateafter.start} - {self.dateafter.end}")
+        logger.info(f"videos in date range: {self.dateafter.start} - {datetime.datetime.today().strftime('%Y-%m-%d')}")
         # download videos (and recompress)
         logger.info(
             f"downloading all videos, subtitles and thumbnails (concurrency={self.max_concurrency})"
@@ -400,7 +400,7 @@ class Youtube2Zim(object):
         """ prepare a list of Playlist from user request
 
             USER: we fetch the hidden channel associate to it
-            CHANNEL (and USER): we grab all playlistFs + `uploads` playlist
+            CHANNEL (and USER): we grab all playlists + `uploads` playlist
             PLAYLIST: we retrieve from the playlist Id(s) """
 
         if self.is_user or self.is_channel:

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -228,10 +228,11 @@ class Youtube2Zim(object):
         )
 
     def run(self):
-        """ validate dateafter input """
+        """ execute the scraper step by step """
+
+        # validate dateafter input
         self.validate_dateafter_input()
 
-        """ execute the scraper step by step """
         logger.info(
             f"starting youtube scraper for {self.collection_type}#{self.youtube_id}"
         )

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -65,6 +65,7 @@ class Youtube2Zim(object):
         language,
         locale_name,
         tags,
+        dateafter,
         title=None,
         description=None,
         creator=None,
@@ -80,6 +81,7 @@ class Youtube2Zim(object):
         self.collection_type = collection_type
         self.youtube_id = youtube_id
         self.api_key = api_key
+        self.dateafter = youtube_dl.DateRange(dateafter)
 
         # video-encoding info
         self.video_format = video_format
@@ -454,6 +456,7 @@ class Youtube2Zim(object):
             "retries": 20,
             "fragment-retries": 50,
             "skip-unavailable-fragments": True,
+            "daterange": self.dateafter,
             # "external_downloader": "aria2c",
             # "external_downloader_args": ["--max-tries=20", "--retry-wait=30"],
             "outtmpl": str(self.videos_dir.joinpath("%(id)s", "video.%(ext)s")),


### PR DESCRIPTION
Fixes #31 

### Context
- Allow user to add a parameter to filter and download videos uploaded on or after the specified date.

### Approach
- Used `youtube_dl.DateRange` to specify daterange
- Used Youtube API to get published date