### PR TITLE
Fixed #70: change requested formats

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Current
+ Fixed video without sound due to change on Youtube side (#70)
+
 Version 2.1.1
  Using zimscraperlib
 

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -464,6 +464,10 @@ class Youtube2Zim(object):
 
     def download_video_files(self, max_concurrency):
 
+        audext, vidext = {"webm": ("webm", "webm"), "mp4": ("m4a", "mp4")}[
+            self.video_format
+        ]
+
         # prepare options which are shared with every downloader
         options = {
             "cachedir": self.videos_dir,
@@ -481,7 +485,7 @@ class Youtube2Zim(object):
             # "external_downloader_args": ["--max-tries=20", "--retry-wait=30"],
             "outtmpl": str(self.videos_dir.joinpath("%(id)s", "video.%(ext)s")),
             "preferredcodec": self.video_format,
-            "format": "{fmt}/best".format(fmt=self.video_format),
+            "format": f"best[ext={vidext}]/bestvideo[ext={vidext}]+bestaudio[ext={audext}]/best",
             "progress_hooks": [
                 partial(hook_youtube_dl_ffmpeg, self.video_format, self.low_quality)
             ],


### PR DESCRIPTION
Requested format for videos was `webm` or `mp4` based on user selection.
This used to be fine as most videos would return a usable video for both format or
fallback and convert to the requested format.
Recently, Youtube changed and seems to not offer video with audio option for `webm`.
As `webm` is also used for audio, Youtube-dl would consider this a video-only webm
request, given the available formats.
This resulted in all videos being silently without audio.

This fixes it by specifically requesting the best available audio+video for `format` and if
not available would request and merge separate files for both and if still not, would
request the best available video+audio and convert it as before