### PR TITLE
Clearer recompress handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 2.1.4
+
+ Fixed compression issue on system without swap (#75)
+
 Version 2.1.3
  Fixed regresssion on --low-quality not working anymore
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ youtube_dl
 python-dateutil==2.8.0
 jinja2==2.10.1
 babel==2.7.0
-zimscraperlib>=1.0.3,<1.1
+zimscraperlib>=1.0.5,<1.1
 requests>=2.23,<3.0
 kiwixstorage>=0.2,<1.0
 pif==0.8.2

--- a/youtube2zim/converter.py
+++ b/youtube2zim/converter.py
@@ -60,7 +60,7 @@ def post_process_video(
         return
 
     dst_path = src_path.parent.joinpath(f"video.{video_format}")
-    recompress_video(src_path, dst_path, video_format, low_quality)
+    recompress_video(src_path, dst_path, video_format)
 
 
 def recompress_video(src_path, dst_path, video_format):

--- a/youtube2zim/reencode_low_quality.py
+++ b/youtube2zim/reencode_low_quality.py
@@ -42,7 +42,7 @@ def main(build_path):
         video_path = build_dir.joinpath("videos", video_id, f"video.{video_format}")
         logger.info(video_path)
 
-        recompress_video(video_path, video_path, video_format, True)
+        recompress_video(video_path, video_path, video_format)
 
     logger.info("all done.")
 

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -310,7 +310,7 @@ class Youtube2Zim(object):
         logger.info(f"  generated-subtitles: {self.all_subtitles}")
         if self.s3_storage:
             logger.info(
-                f"  using cache: {self.s3_storage.url.netloc}  bucket: {self.s3_storage.bucket_name}"
+                f"  using cache: {self.s3_storage.url.netloc} with bucket: {self.s3_storage.bucket_name}"
             )
         if not self.skip_download:
             succeeded, failed = self.download_video_files(
@@ -603,9 +603,9 @@ class Youtube2Zim(object):
         try:
             self.s3_storage.download_file(key, video_path)
         except Exception as exc:
-            logger.error(f"{key} download failed with {exc}")
+            logger.error(f"{key} failed to download from cache: {exc}")
             return False
-        logger.info(f"cache ({key}) downloaded {video_path}")
+        logger.info(f"downloaded {video_path} from cache at {key}")
         return True
 
     def upload_to_cache(self, key, video_path):
@@ -615,9 +615,9 @@ class Youtube2Zim(object):
                 video_path, key, meta={"encoder_version": ENCODER_VERSION}
             )
         except Exception as exc:
-            logger.error(f"{key} upload failed with {exc}")
+            logger.error(f"{key} failed to upload to cache: {exc}")
             return False
-        logger.info(f"video cached to {key}")
+        logger.info(f"uploaded {video_path} to cache at {key}")
         return True
 
     def download_video_files_batch(self, options, videos_ids):


### PR DESCRIPTION
* Fixes #75 by adding `max_muxing_queue_size` to FFmpeg args.
* removes old code for recompressing in high quality (unused)
* better variable names for triggering this
* better wording for S3 logs