### PR TITLE
Fixes #54 - Hide picture-in-picture toggle

### DIFF
--- a/youtube2zim/templates/article.html
+++ b/youtube2zim/templates/article.html
@@ -26,7 +26,8 @@
             <video  class="video-js vjs-default-skin"
                     id="video_container"
                     poster="videos/{{ video_id }}/video.jpg"
-                    width="480px" height="270px">
+                    width="480px" height="270px"
+                    data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
                 <source src="videos/{{ video_id }}/video.{{ video_format }}" type="video/{{ video_format }}" />{% if subtitles %}
                 {% for language in subtitles %}<track kind="subtitles" src="videos/{{ video_id }}/video.{{ language.code }}.vtt" srclang="{{ language.code }}" label="{{ language.native }}" />
                 {% endfor %}{% endif %}
@@ -36,9 +37,5 @@
             </div>
             <div id="date">{{ date }}</div>
         </div>
-        <script>
-            video_container_element = document.getElementById("video_container");
-            video_container_element.setAttribute("data-setup", "{\"techOrder\": [\"html5\", \"ogvjs\"], \"ogvjs\": {\"base\": \"assets/ogvjs\"}, \"autoplay\": {% if autoplay %}true{% else %}false{% endif %}, \"preload\": true, \"controls\": true, \"controlBar\": { \"pictureInPictureToggle\":" + !!document.pictureInPictureEnabled +  "}}");
-        </script>
     </body>
 </html>

--- a/youtube2zim/templates/article.html
+++ b/youtube2zim/templates/article.html
@@ -26,8 +26,7 @@
             <video  class="video-js vjs-default-skin"
                     id="video_container"
                     poster="videos/{{ video_id }}/video.jpg"
-                    width="480px" height="270px"
-                    data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true}'>
+                    width="480px" height="270px">
                 <source src="videos/{{ video_id }}/video.{{ video_format }}" type="video/{{ video_format }}" />{% if subtitles %}
                 {% for language in subtitles %}<track kind="subtitles" src="videos/{{ video_id }}/video.{{ language.code }}.vtt" srclang="{{ language.code }}" label="{{ language.native }}" />
                 {% endfor %}{% endif %}
@@ -37,5 +36,9 @@
             </div>
             <div id="date">{{ date }}</div>
         </div>
+        <script>
+            video_container_element = document.getElementById("video_container");
+            video_container_element.setAttribute("data-setup", "{\"techOrder\": [\"html5\", \"ogvjs\"], \"ogvjs\": {\"base\": \"assets/ogvjs\"}, \"autoplay\": {% if autoplay %}true{% else %}false{% endif %}, \"preload\": true, \"controls\": true, \"controlBar\": { \"pictureInPictureToggle\":" + !!document.pictureInPictureEnabled +  "}}");
+        </script>
     </body>
 </html>

--- a/youtube2zim/templates/assets/app.js
+++ b/youtube2zim/templates/assets/app.js
@@ -139,7 +139,7 @@ function firstVideo(video) {
                'width="480px" height="270px" crossorigin ' +
                'data-setup=\'{"techOrder": ["html5", "ogvjs"], ' + 
                             '"ogvjs": {"base": "assets/ogvjs"}, "autoplay": false, ' +
-                                      '"preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":' + !!document.pictureInPictureEnabled +  '}}\'' +
+                                      '"preload": true, "controls": true, "controlBar": {"pictureInPictureToggle": false}}\'' +
                'poster="' + ZIM_IMG_NS + 'videos/' + video['id'] + '/video.jpg">' +
             '<source src="' + ZIM_IMG_NS + 'videos/' + video['id'] + '/video.{{ video_format }}" ' +
                     'type="video/{{ video_format }}" />' + subtitles + '</video>' +

--- a/youtube2zim/templates/assets/app.js
+++ b/youtube2zim/templates/assets/app.js
@@ -139,7 +139,7 @@ function firstVideo(video) {
                'width="480px" height="270px" crossorigin ' +
                'data-setup=\'{"techOrder": ["html5", "ogvjs"], ' + 
                             '"ogvjs": {"base": "assets/ogvjs"}, "autoplay": false, ' +
-                                      '"preload": true, "controls": true}\' ' +
+                                      '"preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":' + !!document.pictureInPictureEnabled +  '}}\'' +
                'poster="' + ZIM_IMG_NS + 'videos/' + video['id'] + '/video.jpg">' +
             '<source src="' + ZIM_IMG_NS + 'videos/' + video['id'] + '/video.{{ video_format }}" ' +
                     'type="video/{{ video_format }}" />' + subtitles + '</video>' +


### PR DESCRIPTION
Fixes #54 by not displaying PIP toggle if its not supported by the browser. Tested on kiwix-serve versions and Kiwix desktop on Windows and Linux.

@rgaudin could you please confirm if this works on Safari on MacOS?