### PR TITLE
Fixed #93: Support all playlists as individual zims

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Version 2.1.5
 
 Fixed regression causing S3 to only use videos from cache (never youtube)
+Added youtube2zim-playlists script to create one zim per playlist
 
 Version 2.1.4
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,62 @@ youtube2zim --api-key "<your-api-key>" --type user --id "Vsauce"
 * Your API_KEY is subject to usage quotas (10,000 requests/day) so use `--only_test_branding` when adjusting parameters and branding to not *waste your quota*.
 * If you encounter issues reading ZIM files created using this scraper, please take a look at the [Compatibility Matrix](https://github.com/openzim/youtube/wiki/Compatibility) before opening a ticket.
 
+youtube2zim-playlists
+---------------------
+
+`youtube2zim` produces a single ZIM file for a youtube request (`channel`, `user`, `playlists`.
+
+`youtube2zim-playlists` allows you to **create one ZIM file per playlist** instead.
+
+This script is a wrapper around `youtube2zim` and is bundled with the main package.
+
+## Usage
+
+`youtube2zim-playlists --help`
+
+Sample usage:
+
+```
+youtube2zim-playlists --indiv-playlists --api-key XXX --type user --id Vsauce --playlists-name="vsauce_en_playlist-{playlist_id}"
+```
+
+Those are the required arguments for `youtube2zim-playlists` but **you can also pass any regular `youtube2zim` argument**. Those will be forwarded to `youtube2zim` (which will be run independently for each playlist).
+
+**Specificities**:
+
+- `--title` and `--description` are mutually exclusive with `--playlists-title` and `--playlists-description`.
+- If using `--title` or `--description`, all your playlists ZIMs will have the same, static metadata. This is rarely wanted.
+- `--playlists-title` and `--playlists-description` allows you to dynamically customize them via some playlist-related variables:
+  - `{title}`: the playlist title
+  - `{description}`: the playlist description
+  - `{slug}`: slugified version of the playlist title
+  - `{playlist_id}`: playlist ID on youtube
+  - `{creator_id}`: playlist's owner channel/user ID.
+  - `{creator_name}`: playlist's owner channel/user name.
+- You can omit them and `youtube2zim` will auto-generate those.
+- you **must specify `--playlists-name`** (supports variables listed above).
+- `--playlists-name` is used to set the `Name` metadata of the ZIM (should be unique) and if not set separately, the output file name for the ZIM.
+- `--metadata-from` allows to specify a path or URL to a JSON file specifying custom static metadata for individual playlists. Format:
+
+``` json
+{
+    "<playlist-id>": {
+        "name": "",
+        "zim-file": "",
+        "title": "",
+        "description": "",
+        "tags": "",
+        "creator": "",
+        "profile": "",
+        "banner": "",
+    }
+}
+```
+
+All fields are optional and taken from command-line/default if not found. `<playlist-id>` represents the Youtube Playlist ID.
+
+If you feel the need for setting additional details in this file, chances are you should run `youtube2zim` independently for that playlist (still possible!)
+
 Development
 -----------
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,12 @@ setup(
     ],
     zip_safe=False,
     include_package_data=True,
-    entry_points={"console_scripts": ["youtube2zim=youtube2zim.__main__:main"]},
+    entry_points={
+        "console_scripts": [
+            "youtube2zim=youtube2zim.__main__:main",
+            "youtube2zim-playlists=youtube2zim.playlists.__main__:main",
+        ]
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/youtube2zim/playlists/__main__.py
+++ b/youtube2zim/playlists/__main__.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4 nu
+
+import sys
+import pathlib
+
+
+def main():
+    # allows running it from source using python youtube2zim
+    sys.path = [str(pathlib.Path(__file__).parent.parent.parent.resolve())] + sys.path
+
+    from youtube2zim.playlists.entrypoint import main as entry
+
+    entry()
+
+
+if __name__ == "__main__":
+    main()

--- a/youtube2zim/playlists/entrypoint.py
+++ b/youtube2zim/playlists/entrypoint.py
@@ -67,10 +67,13 @@ def main():
 
     args, extra_args = parser.parse_known_args()
 
+    def has_arg(arg):
+        # whether arg is specified in extra_args
+        return list(filter(lambda x: x.startswith(f"--{arg}"), extra_args))
+
     # prevent setting --title and --description
     for arg in ("name", "title", "description"):
-        has_arg = list(filter(lambda x: x.startswith(f"--{arg}"), extra_args))
-        if args.playlists_mode and has_arg:
+        if args.playlists_mode and has_arg(arg):
             parser.error(
                 f"Can't use --{arg} in playlists mode. Use --playlists-{arg} to set format."
             )

--- a/youtube2zim/playlists/entrypoint.py
+++ b/youtube2zim/playlists/entrypoint.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4 nu
+
+import logging
+import argparse
+
+from ..constants import NAME, SCRAPER, CHANNEL, PLAYLIST, USER, logger
+from .scraper import YoutubeHandler
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog=f"{NAME}-playlists",
+        description="Scraper to create ZIM file(s) from a Youtube Channel or Playlists",
+        epilog="Playlists titles, descriptions and names can use the following variables: {title}, {description}, {playlist_id}, {slug} (from title), {creator_id}, {creator_name}.",
+    )
+
+    parser.add_argument(
+        "--type",
+        help="Type of collection",
+        choices=[CHANNEL, PLAYLIST, USER],
+        required=True,
+        dest="collection_type",
+    )
+    parser.add_argument(
+        "--id", help="Youtube ID of the collection", required=True, dest="youtube_id"
+    )
+
+    parser.add_argument("--api-key", help="Youtube API Token", required=True)
+
+    parser.add_argument(
+        "--output",
+        help="Output folder for ZIM file or build folder",
+        default="/output",
+        dest="output_dir",
+    )
+
+    parser.add_argument(
+        "--indiv-playlists",
+        help="Playlists mode: build one ZIM per playlist of the channel",
+        action="store_true",
+        dest="playlists_mode",
+    )
+
+    parser.add_argument(
+        "--playlists-name",
+        help="Format for building individual --name argument. Required in playlist mode.",
+        required=True,
+    )
+    parser.add_argument(
+        "--playlists-title", help="Custom title format for individual playlist ZIM",
+    )
+    parser.add_argument(
+        "--playlists-description",
+        help="Custom description format for individual playlist ZIM",
+    )
+    parser.add_argument(
+        "--debug", help="Enable verbose output", action="store_true", default=False
+    )
+    parser.add_argument(
+        "--version",
+        help="Display scraper version and exit",
+        action="version",
+        version=SCRAPER,
+    )
+
+    args, extra_args = parser.parse_known_args()
+
+    # prevent setting --title and --description
+    for arg in ("name", "title", "description"):
+        has_arg = list(filter(lambda x: x.startswith(f"--{arg}"), extra_args))
+        if args.playlists_mode and has_arg:
+            parser.error(
+                f"Can't use --{arg} in playlists mode. Use --playlists-{arg} to set format."
+            )
+
+    # playlists-name mandatory in playlist-mode
+    if args.playlists_mode and not args.playlists_name:
+        parser.error("--playlists-name is mandatory in playlists mode")
+
+    logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
+
+    try:
+        handler = YoutubeHandler(dict(args._get_kwargs()), extra_args=extra_args)
+        handler.run()
+    except Exception as exc:
+        logger.error(f"FAILED. An error occurred: {exc}")
+        if args.debug:
+            logger.exception(exc)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/youtube2zim/playlists/entrypoint.py
+++ b/youtube2zim/playlists/entrypoint.py
@@ -6,7 +6,7 @@ import logging
 import argparse
 
 from ..constants import NAME, SCRAPER, CHANNEL, PLAYLIST, USER, logger
-from .scraper import YoutubeHandler
+from ..utils import has_argument
 
 
 def main():
@@ -49,11 +49,19 @@ def main():
         required=True,
     )
     parser.add_argument(
+        "--playlists-zim-file",
+        help="Format for building individual --zim-file argument. Uses --playlists-name otherwise",
+    )
+    parser.add_argument(
         "--playlists-title", help="Custom title format for individual playlist ZIM",
     )
     parser.add_argument(
         "--playlists-description",
         help="Custom description format for individual playlist ZIM",
+    )
+    parser.add_argument(
+        "--metadata-from",
+        help="File path or URL to a JSON file holding custom metadata for individual playlists. Format in README",
     )
     parser.add_argument(
         "--debug", help="Enable verbose output", action="store_true", default=False
@@ -67,13 +75,9 @@ def main():
 
     args, extra_args = parser.parse_known_args()
 
-    def has_arg(arg):
-        # whether arg is specified in extra_args
-        return list(filter(lambda x: x.startswith(f"--{arg}"), extra_args))
-
     # prevent setting --title and --description
-    for arg in ("name", "title", "description"):
-        if args.playlists_mode and has_arg(arg):
+    for arg in ("name", "title", "description", "zim-file"):
+        if args.playlists_mode and has_argument(arg, extra_args):
             parser.error(
                 f"Can't use --{arg} in playlists mode. Use --playlists-{arg} to set format."
             )
@@ -83,6 +87,8 @@ def main():
         parser.error("--playlists-name is mandatory in playlists mode")
 
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
+
+    from .scraper import YoutubeHandler
 
     try:
         handler = YoutubeHandler(dict(args._get_kwargs()), extra_args=extra_args)

--- a/youtube2zim/playlists/scraper.py
+++ b/youtube2zim/playlists/scraper.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4 nu
+
+"""
+    Youtube Playlists to individual ZIMs scraper
+
+    Invokes youtube2zim scraper individally for each playlist
+    Also forwards regular requests to youtube2zim (can be used as generic entrypoint)
+
+    - Uploads playlist (all videos of the channel) is excluded
+    - Only displays youtube2zim's output on failure
+"""
+
+import re
+import sys
+import shutil
+import pathlib
+import subprocess
+
+from zimscraperlib.logging import nicer_args_join
+
+from ..constants import logger, NAME, YOUTUBE, PLAYLIST
+from ..youtube import extract_playlists_details_from, credentials_ok
+from ..utils import make_build_folder
+
+
+class YoutubeHandler(object):
+    def __init__(
+        self, options, extra_args,
+    ):
+        # save options as properties
+        for key, value in options.items():
+            setattr(self, key, value)
+        self.extra_args = extra_args
+
+        self.output_dir = pathlib.Path(self.output_dir).expanduser().resolve()
+        self.build_dir = self.output_dir.joinpath("build")
+
+        # update youtube credentials store
+        YOUTUBE.update(
+            build_dir=self.build_dir,
+            api_key=self.api_key,
+            cache_dir=self.build_dir.joinpath("cache"),
+        )
+
+    @property
+    def youtube2zim_exe(self):
+        """ youtube2zim executable """
+
+        # handle either `python youtube2zim` and `youtube2zim`
+        executable = pathlib.Path(sys.executable)
+        if re.match(r"python[0-9]*", executable.name):
+            return [str(executable), "youtube2zim"]
+        return [str(executable)]
+
+    def run(self):
+        # drop directly to regular youtube2zim if not requesting indiv playlits zims
+        if not self.playlists_mode:
+            return self.handle_single_zim()
+
+        logger.info(
+            f"starting all-playlits {NAME} scraper for {self.collection_type}#{self.youtube_id}"
+        )
+
+        # prepare main build dir (only for cache playlists computation data)
+        if self.build_dir.exists():
+            shutil.rmtree(self.build_dir, ignore_errors=True)
+        make_build_folder(self.build_dir)
+
+        logger.info("testing Youtube credentials")
+        if not credentials_ok():
+            raise ValueError("Unable to connect to Youtube API v3. check `API_KEY`.")
+
+        logger.info("compute playlists list to retrieve")
+        (
+            playlists,
+            main_channel_id,
+            uploads_playlist_id,
+        ) = extract_playlists_details_from(self.collection_type, self.youtube_id)
+
+        logger.info(
+            ".. {} playlists:\n   {}".format(
+                len(playlists), "\n   ".join([p.playlist_id for p in playlists]),
+            )
+        )
+
+        for playlist in playlists:
+            if playlist.playlist_id == uploads_playlist_id:
+                logger.info(f"Skipping playlist {playlist.playlist_id} (uploads one)")
+                continue
+
+            logger.info(f"Executing youtube2zim for playlist {playlist.playlist_id}")
+            success, process = self.run_playlist_zim(playlist)
+            if success:
+                logger.info(".. OK")
+            else:
+                logger.error(".. ERROR. Printing scraper output and exiting.")
+                logger.error(process.stdout)
+                return process.returncode
+
+    def run_playlist_zim(self, playlist):
+        """ run youtube2zim for an individual playlist """
+
+        playlist_id = playlist.playlist_id
+        args = self.youtube2zim_exe + [
+            "--type",
+            PLAYLIST,
+            "--id",
+            playlist_id,
+            "--api-key",
+            self.api_key,
+            "--output",
+            str(self.output_dir.joinpath("playlists", playlist_id)),
+            "--name",
+            self.compute_format(playlist, self.playlists_name),
+        ]
+
+        if self.playlists_title:
+            args += ["--title", self.compute_format(playlist, self.playlists_title)]
+
+        if self.playlists_description:
+            args += [
+                "--description",
+                self.compute_format(playlist, self.playlists_description),
+            ]
+
+        args += self.extra_args
+
+        logger.debug(nicer_args_join(args))
+        process = subprocess.run(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+        return process.returncode == 0, process
+
+    def handle_single_zim(self):
+        """ redirect request to standard youtube2zim """
+
+        args = (
+            self.youtube2zim_exe
+            + [
+                "--type",
+                self.collection_type,
+                "--id",
+                self.youtube_id,
+                "--api-key",
+                self.api_key,
+                "--output",
+                self.output_dir,
+            ]
+            + self.extra_args
+        )
+        sys.exit(subprocess.run(args).returncode)
+
+    @staticmethod
+    def compute_format(playlist, fmt):
+        return fmt.format(**playlist.__dict__())

--- a/youtube2zim/playlists/scraper.py
+++ b/youtube2zim/playlists/scraper.py
@@ -14,15 +14,17 @@
 
 import re
 import sys
+import json
 import shutil
 import pathlib
 import subprocess
 
+import requests
 from zimscraperlib.logging import nicer_args_join
 
 from ..constants import logger, NAME, YOUTUBE, PLAYLIST
 from ..youtube import extract_playlists_details_from, credentials_ok
-from ..utils import make_build_folder
+from ..utils import make_build_folder, has_argument
 
 
 class YoutubeHandler(object):
@@ -36,6 +38,12 @@ class YoutubeHandler(object):
 
         self.output_dir = pathlib.Path(self.output_dir).expanduser().resolve()
         self.build_dir = self.output_dir.joinpath("build")
+
+        # metadata_from JSON file
+        self.metadata_from = (
+            pathlib.Path(self.metadata_from) if self.metadata_from else None
+        )
+        self.metadata = {}  # custom metadata holder
 
         # update youtube credentials store
         YOUTUBE.update(
@@ -71,6 +79,8 @@ class YoutubeHandler(object):
         logger.info("testing Youtube credentials")
         if not credentials_ok():
             raise ValueError("Unable to connect to Youtube API v3. check `API_KEY`.")
+
+        self.fetch_metadata()
 
         logger.info("compute playlists list to retrieve")
         (
@@ -112,19 +122,37 @@ class YoutubeHandler(object):
             self.api_key,
             "--output",
             str(self.output_dir.joinpath("playlists", playlist_id)),
-            "--name",
-            self.compute_format(playlist, self.playlists_name),
         ]
 
-        if self.playlists_title:
-            args += ["--title", self.compute_format(playlist, self.playlists_title)]
+        # set metadata args for playlist
+        metadata = self.metadata.get(playlist_id, {})
+        for key in (
+            "name",
+            "zim-file",
+            "title",
+            "description",
+            "tags",
+            "creator",
+            "profile",
+            "banner",
+        ):
+            # use value from metadata JSON if present else from command-line
+            value = metadata.get(
+                key, getattr(self, f"playlists_{key.replace('-', '_')}", None)
+            )
 
-        if self.playlists_description:
+            if value:  # only set arg if we have a value so it can be defaulted
+                # format value using playlists' variables
+                args += [f"--{key}", self.compute_format(playlist, str(value))]
+
+        # ensure we supplied a name
+        if not has_argument("name", args):
             args += [
-                "--description",
-                self.compute_format(playlist, self.playlists_description),
+                "--name",
+                self.compute_format(playlist, self.playlists_name),
             ]
 
+        # append regular youtube2zim args
         args += self.extra_args
 
         logger.debug(nicer_args_join(args))
@@ -158,3 +186,37 @@ class YoutubeHandler(object):
     @staticmethod
     def compute_format(playlist, fmt):
         return fmt.format(**playlist.__dict__())
+
+    def fetch_metadata(self):
+        """ retrieves and loads metadata from --metadata-from """
+
+        if not self.metadata_from:
+            return
+
+        logger.info(f"Retrieving custom metadata from {self.metadata_from}")
+        # load JSON from source (URL or file)
+        try:
+            if str(self.metadata_from).startswith("http"):
+                self.metadata = requests.get(str(self.metadata_from)).json()
+            else:
+                if not self.metadata_from.exists():
+                    raise IOError(
+                        f"--metadata-from file could not be found: {self.metadata_from}"
+                    )
+                with open(self.metadata_from, "r") as fh:
+                    self.metadata = json.load(fh)
+        except Exception as exc:
+            logger.debug(exc)
+            raise ValueError(
+                f"--metadata-from could not be loaded as JSON: {self.metadata_from}"
+            )
+
+        # ensure the basic format is respected: dict of playlist ID to dict of meta
+        if not isinstance(self.metadata, dict) or len(self.metadata) != sum(
+            [
+                1
+                for k, v in self.metadata.items()
+                if isinstance(k, str) and isinstance(v, dict)
+            ]
+        ):
+            raise ValueError("--metadata-from JSON is of unexpected format")

--- a/youtube2zim/utils.py
+++ b/youtube2zim/utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # vim: ai ts=4 sts=4 et sw=4 nu
 
+import os
 import json
 
 from slugify import slugify
@@ -35,3 +36,16 @@ def load_json(cache_dir, key):
             return json.load(fp)
     except Exception:
         return None
+
+
+def make_build_folder(build_dir):
+    """ prepare build folder before we start
+
+        cache for youtube-API requests cache
+        videos for storing video files
+        channels for channel-related files (profile pics) """
+
+    os.makedirs(build_dir, exist_ok=True)
+
+    for sub_folder in ("cache", "videos", "channels"):
+        build_dir.joinpath(sub_folder).mkdir(exist_ok=True)

--- a/youtube2zim/utils.py
+++ b/youtube2zim/utils.py
@@ -49,3 +49,8 @@ def make_build_folder(build_dir):
 
     for sub_folder in ("cache", "videos", "channels"):
         build_dir.joinpath(sub_folder).mkdir(exist_ok=True)
+
+
+def has_argument(arg_name, all_args):
+    """ whether --arg_name is specified in all_args """
+    return list(filter(lambda x: x.startswith(f"--{arg_name}"), all_args))


### PR DESCRIPTION
Here's a simpler approach to implementing #93 .

Instead of reimplementing all arguments in a different script (duplicating a lot of tedious code),
this only implements the required ones (api-key, type and ID) and keeps the rest for later use.

This *scraper* has very limited code that first checks whether we're in playlists mode (`--indiv-playlists` – open to suggestions for a better arg name!) and if not, directly calls youtube2zim.

When in playlists mode, after checking the credentials, it extracts the list of playlists using the same function youtube2zim uses and run youtube2zim for each of them.

Main differences:

- This script is usable as a replacement of the docker command as it handles both regular and playlists request ; a requirement for the zimfarm which supports only a single command per scraper.

- `--playlists-name`, `--playlists-title`, `--playlists-description` are used to build the respective args of youtube2zim but accepts some variables: `title`, `description`, `slug` (from title), `playlist_id`, `creator_id`, `creator_name`.

While this is great for title and description, name is not ideal as this build the filename as well and the `slug` is just a derivation of the title which can be very long and convoluted… 

So we'd endup with either unreadable (using playlist_id) or out-of-convention (using slug) file names.
We've already discussed that filenames are not expected to have meanings and that we have metadata for that… but I think it will be the first time this gets enforced.

At the moment, all of them are mandatory. Should we loosen up a bit and autofill title and description?

Very minor changes to the current scraper:
- moved logic of extract_playlist into youtube sub module for reuse
- moved build folder creation to utils sub module for reuse