### PR TITLE
Use temporary build_dir

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,8 +7,7 @@ picture-in-picture toggle now hidden
 using zimscraperlib to encode videos
 logging transfer before starting them
 added video_encoding_tester script in contrib/
-build-dir is temporary by default
---build-dir introduced to support custom build directory
+--tmp-dir option to set where temp files are downloaded/handled (system temp otherwise)
 
 Version 2.1.5
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ picture-in-picture toggle now hidden
 using zimscraperlib to encode videos
 logging transfer before starting them
 added video_encoding_tester script in contrib/
+build-dir is temporary by default
+--build-dir introduced to support custom build directory
 
 Version 2.1.5
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ Those are the required arguments for `youtube2zim-playlists` but **you can also 
         "tags": "",
         "creator": "",
         "profile": "",
-        "banner": "",
-        "build-dir": "",
+        "banner": ""
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Those are the required arguments for `youtube2zim-playlists` but **you can also 
         "creator": "",
         "profile": "",
         "banner": "",
+        "build-dir": "",
     }
 }
 ```

--- a/youtube2zim/entrypoint.py
+++ b/youtube2zim/entrypoint.py
@@ -67,13 +67,14 @@ def main():
 
     parser.add_argument(
         "--output",
-        help="Output folder for ZIM file or build folder",
+        help="Output folder for ZIM file",
         default="/output",
         dest="output_dir",
     )
 
     parser.add_argument(
-        "--build-dir", help="Custom build folder to build ZIM from",
+        "--tmp-dir",
+        help="Path to create temp folder in. Used for building ZIM file. Receives all data (storage space)",
     )
 
     parser.add_argument(

--- a/youtube2zim/entrypoint.py
+++ b/youtube2zim/entrypoint.py
@@ -71,12 +71,18 @@ def main():
         default="/output",
         dest="output_dir",
     )
+
+    parser.add_argument(
+        "--build-dir", help="Custom build folder to build ZIM from",
+    )
+
     parser.add_argument(
         "--no-zim",
         help="Don't produce a ZIM file, create HTML folder only.",
         action="store_true",
         default=False,
     )
+
     parser.add_argument(
         "--zim-file",
         help="ZIM file name (based on --name if not provided). If used, {period} is replaced with date as of YYYY-MM",
@@ -86,45 +92,55 @@ def main():
     parser.add_argument(
         "--language", help="ISO-639-3 (3 chars) language code of content", default="eng"
     )
+
     parser.add_argument(
         "--locale",
         help="Locale name to use for translations (if avail) and time representations. Defaults to --language or English.",
         dest="locale_name",
     )
+
     parser.add_argument(
         "--title",
         help="Custom title for your project and ZIM. Default to Channel name (of first video if playlists)",
     )
+
     parser.add_argument(
         "--description",
         help="Custom description for your project and ZIM. Default to Channel name (of first video if playlists)",
     )
+
     parser.add_argument(
         "--creator",
         help="Name of content creator. Defaults to Channel name or “Youtue Channels”",
     )
+
     parser.add_argument(
         "--publisher", help="Custom publisher name (ZIM metadata)", default="Kiwix"
     )
+
     parser.add_argument(
         "--tags",
         help="List of comma-separated Tags for the ZIM file. _videos:yes added automatically",
         default="youtube",
     )
+
     parser.add_argument(
         "--profile",
         help="Custom profile image (path or URL). Squared. Will be resized to 100x100px",
         dest="profile_image",
     )
+
     parser.add_argument(
         "--banner",
         help="Custom banner image (path or URL). Will be resized to 1060x175px",
         dest="banner_image",
     )
+
     parser.add_argument(
         "--main-color",
         help="Custom color. Hex/HTML syntax (#DEDEDE). Default to main color of profile image.",
     )
+
     parser.add_argument(
         "--secondary-color",
         help="Custom secondary color. Hex/HTML syntax (#DEDEDE). Default to secondary color of profile image.",
@@ -133,6 +149,7 @@ def main():
     parser.add_argument(
         "--debug", help="Enable verbose output", action="store_true", default=False
     )
+
     parser.add_argument(
         "--keep",
         help="Don't erase build folder on start (for debug/devel)",
@@ -140,6 +157,7 @@ def main():
         action="store_true",
         dest="keep_build_dir",
     )
+
     parser.add_argument(
         "--skip-download",
         help="Skip the download step (videos, thumbnails, subtitles)",
@@ -147,6 +165,7 @@ def main():
         action="store_true",
         dest="skip_download",
     )
+
     parser.add_argument(
         "--concurrency",
         help="Number of concurrent threads to use",
@@ -154,6 +173,7 @@ def main():
         dest="max_concurrency",
         default=1,
     )
+
     parser.add_argument(
         "--only_test_branding",
         help="Just generate a fake home.html to check branding (images and colors)",
@@ -161,12 +181,14 @@ def main():
         action="store_true",
         dest="only_test_branding",
     )
+
     parser.add_argument(
         "--version",
         help="Display scraper version and exit",
         action="version",
         version=SCRAPER,
     )
+
     parser.add_argument(
         "--dateafter",
         help="Custom filter to download videos uploaded on or after specified date. Format: YYYYMMDD or (now|today)[+-][0-9](day|week|month|year)(s)?",

--- a/youtube2zim/playlists/entrypoint.py
+++ b/youtube2zim/playlists/entrypoint.py
@@ -30,13 +30,6 @@ def main():
     parser.add_argument("--api-key", help="Youtube API Token", required=True)
 
     parser.add_argument(
-        "--output",
-        help="Output folder for ZIM file or build folder",
-        default="/output",
-        dest="output_dir",
-    )
-
-    parser.add_argument(
         "--indiv-playlists",
         help="Playlists mode: build one ZIM per playlist of the channel",
         action="store_true",
@@ -58,6 +51,10 @@ def main():
     parser.add_argument(
         "--playlists-description",
         help="Custom description format for individual playlist ZIM",
+    )
+    parser.add_argument(
+        "--playlists-build-dir",
+        help="Custom format for build directory names for individual ZIMs",
     )
     parser.add_argument(
         "--metadata-from",
@@ -83,8 +80,33 @@ def main():
             )
 
     # playlists-name mandatory in playlist-mode
-    if args.playlists_mode and not args.playlists_name:
-        parser.error("--playlists-name is mandatory in playlists mode")
+    if not args.metadata_from:
+        if args.playlists_mode and not args.playlists_name:
+            parser.error("--playlists-name is mandatory in playlists mode")
+
+        variables_list = [
+            "{title}",
+            "{description}",
+            "{playlist_id}",
+            "{slug}",
+            "{creator_id}",
+            "{creator_name}",
+        ]
+        if args.playlists_name and not [
+            identifier
+            for identifier in variables_list
+            if identifier in args.playlists_name
+        ]:
+            parser.error("--playlists-name must have a variable to ensure unique names")
+
+        if args.playlists_build_dir and not [
+            identifier
+            for identifier in variables_list
+            if identifier in args.playlists_build_dir
+        ]:
+            parser.error(
+                "--playlists-build-dir must have a variable to ensure unique names for custom build directories"
+            )
 
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 

--- a/youtube2zim/playlists/entrypoint.py
+++ b/youtube2zim/playlists/entrypoint.py
@@ -76,8 +76,8 @@ def main():
             )
 
     # playlists-name mandatory in playlist-mode
-    if args.playlists_mode and not args.playlists_name and not args.metadata_from:
-        parser.error("--playlists-name or --metadata-from mandatory in playlists mode")
+    if args.playlists_mode and not args.playlists_name:
+        parser.error("--playlists-name is mandatory in playlists mode")
 
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 

--- a/youtube2zim/playlists/entrypoint.py
+++ b/youtube2zim/playlists/entrypoint.py
@@ -9,44 +9,6 @@ from ..constants import NAME, SCRAPER, CHANNEL, PLAYLIST, USER, logger
 from ..utils import has_argument
 
 
-def check_passed_args(args, extra_args, parser):
-    # prevent setting --title and --description
-    for arg in ("name", "title", "description", "zim-file"):
-        if args.playlists_mode and has_argument(arg, extra_args):
-            parser.error(
-                f"Can't use --{arg} in playlists mode. Use --playlists-{arg} to set format."
-            )
-
-    # playlists-name mandatory in playlist-mode
-    if not args.metadata_from:
-        if args.playlists_mode and not args.playlists_name:
-            parser.error("--playlists-name is mandatory in playlists mode")
-
-        variables_list = [
-            "{title}",
-            "{description}",
-            "{playlist_id}",
-            "{slug}",
-            "{creator_id}",
-            "{creator_name}",
-        ]
-        if args.playlists_name and not [
-            identifier
-            for identifier in variables_list
-            if identifier in args.playlists_name
-        ]:
-            parser.error("--playlists-name must have a variable to ensure unique names")
-
-        if args.playlists_build_dir and not [
-            identifier
-            for identifier in variables_list
-            if identifier in args.playlists_build_dir
-        ]:
-            parser.error(
-                "--playlists-build-dir must have a variable to ensure unique names for custom build directories"
-            )
-
-
 def main():
     parser = argparse.ArgumentParser(
         prog=f"{NAME}-playlists",
@@ -91,10 +53,6 @@ def main():
         help="Custom description format for individual playlist ZIM",
     )
     parser.add_argument(
-        "--playlists-build-dir",
-        help="Custom format for build directory names for individual ZIMs",
-    )
-    parser.add_argument(
         "--metadata-from",
         help="File path or URL to a JSON file holding custom metadata for individual playlists. Format in README",
     )
@@ -110,7 +68,16 @@ def main():
 
     args, extra_args = parser.parse_known_args()
 
-    check_passed_args(args, extra_args, parser)
+    # prevent setting --title and --description
+    for arg in ("name", "title", "description", "zim-file"):
+        if args.playlists_mode and has_argument(arg, extra_args):
+            parser.error(
+                f"Can't use --{arg} in playlists mode. Use --playlists-{arg} to set format."
+            )
+
+    # playlists-name mandatory in playlist-mode
+    if args.playlists_mode and not args.playlists_name and not args.metadata_from:
+        parser.error("--playlists-name or --metadata-from mandatory in playlists mode")
 
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 

--- a/youtube2zim/playlists/scraper.py
+++ b/youtube2zim/playlists/scraper.py
@@ -141,13 +141,6 @@ class YoutubeHandler(object):
                 # format value using playlists' variables
                 args += [f"--{key}", self.compute_format(playlist, str(value))]
 
-        # ensure we supplied a name
-        if not has_argument("name", args):
-            args += [
-                "--name",
-                self.compute_format(playlist, self.playlists_name),
-            ]
-
         # append regular youtube2zim args
         args += self.extra_args
 

--- a/youtube2zim/playlists/scraper.py
+++ b/youtube2zim/playlists/scraper.py
@@ -15,8 +15,8 @@
 import re
 import sys
 import json
-import shutil
 import pathlib
+import tempfile
 import subprocess
 
 import requests
@@ -24,7 +24,7 @@ from zimscraperlib.logging import nicer_args_join
 
 from ..constants import logger, NAME, YOUTUBE, PLAYLIST
 from ..youtube import extract_playlists_details_from, credentials_ok
-from ..utils import make_build_folder, has_argument
+from ..utils import has_argument
 
 
 class YoutubeHandler(object):
@@ -36,8 +36,8 @@ class YoutubeHandler(object):
             setattr(self, key, value)
         self.extra_args = extra_args
 
-        self.output_dir = pathlib.Path(self.output_dir).expanduser().resolve()
-        self.build_dir = self.output_dir.joinpath("build")
+        self.temp_dir = self.temp_dir = tempfile.TemporaryDirectory()
+        self.build_dir = pathlib.Path(self.temp_dir.name)
 
         # metadata_from JSON file
         self.metadata_from = (
@@ -71,10 +71,9 @@ class YoutubeHandler(object):
             f"starting all-playlits {NAME} scraper for {self.collection_type}#{self.youtube_id}"
         )
 
-        # prepare main build dir (only for cache playlists computation data)
-        if self.build_dir.exists():
-            shutil.rmtree(self.build_dir, ignore_errors=True)
-        make_build_folder(self.build_dir)
+        # create required sub folders
+        for sub_folder in ("cache", "videos", "channels"):
+            self.build_dir.joinpath(sub_folder).mkdir(exist_ok=True)
 
         logger.info("testing Youtube credentials")
         if not credentials_ok():
@@ -120,8 +119,6 @@ class YoutubeHandler(object):
             playlist_id,
             "--api-key",
             self.api_key,
-            "--output",
-            str(self.output_dir.joinpath("playlists", playlist_id)),
         ]
 
         # set metadata args for playlist
@@ -135,6 +132,7 @@ class YoutubeHandler(object):
             "creator",
             "profile",
             "banner",
+            "build-dir",
         ):
             # use value from metadata JSON if present else from command-line
             value = metadata.get(
@@ -147,10 +145,9 @@ class YoutubeHandler(object):
 
         # ensure we supplied a name
         if not has_argument("name", args):
-            args += [
-                "--name",
-                self.compute_format(playlist, self.playlists_name),
-            ]
+            raise ValueError(
+                "Cannot supply a --name argument to youtube2zim. Ensure you have a supplied either --playlists-name or have name in metadata JSON"
+            )
 
         # append regular youtube2zim args
         args += self.extra_args
@@ -176,8 +173,6 @@ class YoutubeHandler(object):
                 self.youtube_id,
                 "--api-key",
                 self.api_key,
-                "--output",
-                self.output_dir,
             ]
             + self.extra_args
         )

--- a/youtube2zim/playlists/scraper.py
+++ b/youtube2zim/playlists/scraper.py
@@ -36,8 +36,7 @@ class YoutubeHandler(object):
             setattr(self, key, value)
         self.extra_args = extra_args
 
-        self.temp_dir = self.temp_dir = tempfile.TemporaryDirectory()
-        self.build_dir = pathlib.Path(self.temp_dir.name)
+        self.build_dir = pathlib.Path(tempfile.mkdtemp())
 
         # metadata_from JSON file
         self.metadata_from = (
@@ -73,7 +72,7 @@ class YoutubeHandler(object):
 
         # create required sub folders
         for sub_folder in ("cache", "videos", "channels"):
-            self.build_dir.joinpath(sub_folder).mkdir(exist_ok=True)
+            self.build_dir.joinpath(sub_folder).mkdir()
 
         logger.info("testing Youtube credentials")
         if not credentials_ok():
@@ -132,7 +131,6 @@ class YoutubeHandler(object):
             "creator",
             "profile",
             "banner",
-            "build-dir",
         ):
             # use value from metadata JSON if present else from command-line
             value = metadata.get(
@@ -145,9 +143,10 @@ class YoutubeHandler(object):
 
         # ensure we supplied a name
         if not has_argument("name", args):
-            raise ValueError(
-                "Cannot supply a --name argument to youtube2zim. Ensure you have a supplied either --playlists-name or have name in metadata JSON"
-            )
+            args += [
+                "--name",
+                self.compute_format(playlist, self.playlists_name),
+            ]
 
         # append regular youtube2zim args
         args += self.extra_args

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -70,7 +70,7 @@ class Youtube2Zim(object):
         no_zim,
         fname,
         debug,
-        build_dir,
+        tmp_dir,
         keep_build_dir,
         skip_download,
         max_concurrency,
@@ -121,10 +121,9 @@ class Youtube2Zim(object):
 
         # directory setup
         self.output_dir = Path(output_dir).expanduser().resolve()
-        self.temp_dir = tempfile.TemporaryDirectory() if not build_dir else None
-        self.custom_build_dir = (
-            Path(build_dir).expanduser().resolve() if build_dir else None
-        )
+        if tmp_dir:
+            Path(tmp_dir).mkdir(parents=True, exist_ok=True)
+        self.build_dir = Path(tempfile.mkdtemp(dir=tmp_dir))
 
         # process-related
         self.playlists = []
@@ -185,12 +184,6 @@ class Youtube2Zim(object):
     @property
     def assets_src_dir(self):
         return self.templates_dir.joinpath("assets")
-
-    @property
-    def build_dir(self):
-        return (
-            self.custom_build_dir if self.custom_build_dir else Path(self.temp_dir.name)
-        )
 
     @property
     def assets_dir(self):
@@ -355,20 +348,12 @@ class Youtube2Zim(object):
             logger.info("building ZIM file")
             print(self.zim_info.to_zimwriterfs_args())
             make_zim_file(self.build_dir, self.output_dir, self.fname, self.zim_info)
-        self.post_process_build_dir()
+
+            if not self.keep_build_dir:
+                logger.info("removing temp folder")
+                shutil.rmtree(self.build_dir, ignore_errors=True)
+
         logger.info("all done!")
-
-    def post_process_build_dir(self):
-        """ Deletes/keeps build_dir according to user's choice """
-
-        if self.keep_build_dir and not self.custom_build_dir:
-            logger.info("Saving build directory")
-            shutil.copytree(
-                self.build_dir, self.output_dir.joinpath(f"{self.fname}_build")
-            )
-        elif not self.keep_build_dir and self.custom_build_dir:
-            logger.info("Removing build directory")
-            shutil.rmtree(self.build_dir, ignore_errors=True)
 
     def s3_credentials_ok(self):
         logger.info("testing S3 Optimization Cache credentials")
@@ -397,17 +382,7 @@ class Youtube2Zim(object):
     def prepare_build_folder(self):
         """ prepare build folder before we start downloading data """
 
-        if self.custom_build_dir:
-            if not self.keep_build_dir and self.build_dir.exists():
-                shutil.rmtree(self.cache_dir, ignore_errors=True)
-                shutil.rmtree(self.build_dir)
-
-            # create build folder
-            os.makedirs(self.build_dir, exist_ok=True)
-
         # copy assets
-        if self.assets_dir.exists():
-            shutil.rmtree(self.assets_dir)
         shutil.copytree(self.assets_src_dir, self.assets_dir)
 
         fix_source_dir(self.assets_dir, "assets")

--- a/youtube2zim/utils.py
+++ b/youtube2zim/utils.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 # vim: ai ts=4 sts=4 et sw=4 nu
 
-import os
 import json
 
 from slugify import slugify
@@ -36,19 +35,6 @@ def load_json(cache_dir, key):
             return json.load(fp)
     except Exception:
         return None
-
-
-def make_build_folder(build_dir):
-    """ prepare build folder before we start
-
-        cache for youtube-API requests cache
-        videos for storing video files
-        channels for channel-related files (profile pics) """
-
-    os.makedirs(build_dir, exist_ok=True)
-
-    for sub_folder in ("cache", "videos", "channels"):
-        build_dir.joinpath(sub_folder).mkdir(exist_ok=True)
 
 
 def has_argument(arg_name, all_args):


### PR DESCRIPTION
This fixes #101 by using a temporary directory as build dir by default, and passing --output directly to youtube2zim in playlists mode. Also, a new option --build-dir is introduced for custom build dir location.