### PR TITLE
Fix subtitles display and prevent crash on Hebrew subtitles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 2.1.8.dev0
 
-n/a
+fix subtitles not showing on homepage preview video
+fix crash on iw (Hebrew) subtitles
 
 2.1.7
 

--- a/youtube2zim/constants.py
+++ b/youtube2zim/constants.py
@@ -19,6 +19,8 @@ CHANNEL = "channel"
 PLAYLIST = "playlist"
 USER = "user"
 
+YOUTUBELANGMAP = {"iw": "he"}
+
 logger = getLogger(NAME, level=logging.DEBUG)
 
 

--- a/youtube2zim/constants.py
+++ b/youtube2zim/constants.py
@@ -19,7 +19,8 @@ CHANNEL = "channel"
 PLAYLIST = "playlist"
 USER = "user"
 
-YOUTUBELANGMAP = {"iw": "he"}
+# Youtube uses some non-standard language codes
+YOUTUBE_LANG_MAP = {"iw": "he", "es-419": "es"}
 
 logger = getLogger(NAME, level=logging.DEBUG)
 

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -52,6 +52,7 @@ from .constants import (
     PLAYLIST,
     USER,
     SCRAPER,
+    YOUTUBELANGMAP,
 )
 
 
@@ -105,7 +106,7 @@ class Youtube2Zim(object):
         self.all_subtitles = all_subtitles
         self.autoplay = autoplay
         self.fname = fname
-        self.language = language
+        self.language = self.preprocess_language(language)
         self.tags = [t.strip() for t in tags.split(",")]
         self.title = title
         self.description = description
@@ -234,6 +235,12 @@ class Youtube2Zim(object):
             + sorted_playlists[0:index]
             + sorted_playlists[index + 1 :]
         )
+
+    @staticmethod
+    def preprocess_language(lang):
+        if lang in YOUTUBELANGMAP:
+            return YOUTUBELANGMAP[lang]
+        return lang
 
     def run(self):
         """ execute the scraper step by step """
@@ -735,7 +742,18 @@ class Youtube2Zim(object):
                 if x.is_file() and x.name.endswith(".vtt")
             ]
 
-            return [get_language_details(language) for language in languages]
+            subtitle_details = []
+            for language in languages:
+                language_details = get_language_details(
+                    self.preprocess_language(language)
+                )
+                subtitle_details.append(
+                    {
+                        "code": language,
+                        "display_string": f"{language_details['native']} - {language_details['english']}",
+                    }
+                )
+            return subtitle_details
 
         env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(str(self.templates_dir)), autoescape=True

--- a/youtube2zim/templates/article.html
+++ b/youtube2zim/templates/article.html
@@ -26,7 +26,7 @@
                     width="480px" height="270px"
                     data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
                 <source src="videos/{{ video_id }}/video.{{ video_format }}" type="video/{{ video_format }}" />{% if subtitles %}
-                {% for language in subtitles %}<track kind="subtitles" src="videos/{{ video_id }}/video.{{ language.code }}.vtt" srclang="{{ language.code }}" label="{{ language.display_string }}" />
+                {% for language in subtitles %}<track kind="subtitles" src="videos/{{ video_id }}/video.{{ language.code }}.vtt" srclang="{{ language.code }}" label="{{ language.name }}" />
                 {% endfor %}{% endif %}
             </video>
             <div id="description">

--- a/youtube2zim/templates/article.html
+++ b/youtube2zim/templates/article.html
@@ -26,7 +26,7 @@
                     width="480px" height="270px"
                     data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
                 <source src="videos/{{ video_id }}/video.{{ video_format }}" type="video/{{ video_format }}" />{% if subtitles %}
-                {% for language in subtitles %}<track kind="subtitles" src="videos/{{ video_id }}/video.{{ language.code }}.vtt" srclang="{{ language.code }}" label="{{ language.native }}" />
+                {% for language in subtitles %}<track kind="subtitles" src="videos/{{ video_id }}/video.{{ language.code }}.vtt" srclang="{{ language.code }}" label="{{ language.display_string }}" />
                 {% endfor %}{% endif %}
             </video>
             <div id="description">

--- a/youtube2zim/templates/assets/app.js
+++ b/youtube2zim/templates/assets/app.js
@@ -127,7 +127,7 @@ function firstVideo(video) {
     if (video['subtitles'].length > 0) {
         for (i in video['subtitles']) {
             var subtitle = video['subtitles'][i];
-            subtitles += '<track kind="subtitles" src="videos/' + video['id'] + '/video.' + subtitle['code'] + '.vtt" srclang="' + subtitle['code'] + '" label="' + subtitle['native'] + '" />';
+            subtitles += '<track kind="subtitles" src="' + ZIM_META_NS + 'videos/' + video['id'] + '/video.' + subtitle['code'] + '.vtt" srclang="' + subtitle['code'] + '" label="' + subtitle['display_string'] + '" />';
         }
     }
     var video_desctiption = video['description'].slice(0, 200);

--- a/youtube2zim/templates/assets/app.js
+++ b/youtube2zim/templates/assets/app.js
@@ -127,7 +127,7 @@ function firstVideo(video) {
     if (video['subtitles'].length > 0) {
         for (i in video['subtitles']) {
             var subtitle = video['subtitles'][i];
-            subtitles += '<track kind="subtitles" src="' + ZIM_META_NS + 'videos/' + video['id'] + '/video.' + subtitle['code'] + '.vtt" srclang="' + subtitle['code'] + '" label="' + subtitle['display_string'] + '" />';
+            subtitles += '<track kind="subtitles" src="' + ZIM_META_NS + 'videos/' + video['id'] + '/video.' + subtitle['code'] + '.vtt" srclang="' + subtitle['code'] + '" label="' + subtitle['name'] + '" />';
         }
     }
     var video_desctiption = video['description'].slice(0, 200);


### PR DESCRIPTION
This fixes #112 and has some other subtitle related fixes as follows -

- Fix the namespace for subtitles path in app.js - Subtitles for the main video on the homepage were never loaded, due to incorrect path
- Fix crash on iw (Hebrew) subtitles - Apparently `iw` is not iso-639-1 code. The correct code is `he`. See https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes#HE
- Fix subtitles not showing in article page - Due to incorrect attributes being looked by Jinja2
- Fix subtitle display names and change them to `<native name> - <english name>` - `get_subtitles()` now returns only code and display names as a list of dictionaries.