### PR TITLE
Use WebP for thumbnails and fix seeking on apple browsers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 fixed subtitles not showing on homepage preview video
 fixed crash on iw (Hebrew) subtitles
 fixed usage on older browsers (without ES6 support)
+use WebP for thumbnails and fix seeking on Apple browsers
 
 2.1.7
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,8 @@
 fixed subtitles not showing on homepage preview video
 fixed crash on iw (Hebrew) subtitles
 fixed usage on older browsers (without ES6 support)
-use WebP for thumbnails and fix seeking on Apple browsers
+use WebP for thumbnails
+fix seeking on Apple browsers
 
 2.1.7
 

--- a/get_js_deps.sh
+++ b/get_js_deps.sh
@@ -55,6 +55,14 @@ rm -f v1.3.1.zip
 echo "getting jquery.js"
 curl -L -o $ASSETS_PATH/jquery.min.js https://code.jquery.com/jquery-1.12.4.min.js
 
+echo "getting webp-hero"
+curl -L -O https://unpkg.com/webp-hero@0.0.0-dev.26/dist-cjs/polyfills.js
+rm -f $ASSETS_PATH/polyfills.js
+mv polyfills.js $ASSETS_PATH/polyfills.js
+curl -L -O https://unpkg.com/webp-hero@0.0.0-dev.26/dist-cjs/webp-hero.bundle.js
+rm -f $ASSETS_PATH/webp-hero.bundle.js
+mv webp-hero.bundle.js $ASSETS_PATH/webp-hero.bundle.js
+
 if command -v fix_ogvjs_dist > /dev/null; then
     echo "fixing JS files"
     fix_ogvjs_dist $ASSETS_PATH "assets"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ python-slugify==3.0.3
 youtube_dl
 python-dateutil==2.8.0
 jinja2==2.10.1
-zimscraperlib>=1.2.0,<1.3
+zimscraperlib>=1.3.3,<1.4
 requests>=2.23,<3.0
 kiwixstorage>=0.2,<1.0
 pif==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ python-slugify==3.0.3
 youtube_dl
 python-dateutil==2.8.0
 jinja2==2.10.1
-zimscraperlib>=1.3.3,<1.4
+zimscraperlib>=1.3.4,<1.4
 requests>=2.23,<3.0
 kiwixstorage>=0.2,<1.0
 pif==0.8.2

--- a/youtube2zim/processing.py
+++ b/youtube2zim/processing.py
@@ -3,8 +3,30 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 from zimscraperlib.video.encoding import reencode
+from zimscraperlib.image.optimization import optimize_image
+from zimscraperlib.image.transformation import resize_image
 
 from .constants import logger
+
+
+def process_thumbnail(thumbnail_path, preset):
+    # thumbnail might be WebP as .webp, JPEG as .jpg or WebP as .jpg
+    tmp_thumbnail = thumbnail_path
+    if not thumbnail_path.exists():
+        logger.debug("We don't have video.webp, thumbnail is .jpg")
+        tmp_thumbnail = thumbnail_path.with_suffix(".jpg")
+
+    # resize thumbnail. we use max width:248x187px in listing
+    # but our posters are 480x270px
+    resize_image(
+        tmp_thumbnail,
+        width=480,
+        height=270,
+        method="cover",
+        allow_upscaling=True,
+    )
+    optimize_image(tmp_thumbnail, thumbnail_path, **preset.options)
+    return True
 
 
 def post_process_video(video_dir, video_id, preset, video_format, low_quality):

--- a/youtube2zim/processing.py
+++ b/youtube2zim/processing.py
@@ -3,14 +3,11 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 from zimscraperlib.video.encoding import reencode
-from zimscraperlib.imaging import resize_image, convert_image
 
 from .constants import logger
 
 
-def post_process_video(
-    video_dir, video_id, preset, video_format, low_quality, skip_recompress=False
-):
+def post_process_video(video_dir, video_id, preset, video_format, low_quality):
     """apply custom post-processing to downloaded video
 
     - resize thumbnail
@@ -33,19 +30,8 @@ def post_process_video(
         )
     src_path = files[0]
 
-    # thumbnail might be WebP as .webp, JPEG as .jpg or WebP as .jpg
-    thumbnail = tmp_thumbnail = src_path.with_name("video.jpg")
-    if not thumbnail.exists():
-        logger.debug("We don't have video.jpg, thumbnail is .webp")
-        tmp_thumbnail = thumbnail.with_suffix(".webp")
-    convert_image(tmp_thumbnail, thumbnail, "JPEG")
-
-    # resize thumbnail. we use max width:248x187px in listing
-    # but our posters are 480x270px
-    resize_image(thumbnail, width=480, height=270, method="cover", allow_upscaling=True)
-
     # don't reencode if not requesting low-quality and received wanted format
-    if skip_recompress or (not low_quality and src_path.suffix[1:] == video_format):
+    if not low_quality and src_path.suffix[1:] == video_format:
         return
 
     dst_path = src_path.with_name(f"video.{video_format}")

--- a/youtube2zim/processing.py
+++ b/youtube2zim/processing.py
@@ -25,7 +25,7 @@ def process_thumbnail(thumbnail_path, preset):
         method="cover",
         allow_upscaling=True,
     )
-    optimize_image(tmp_thumbnail, thumbnail_path, **preset.options)
+    optimize_image(tmp_thumbnail, thumbnail_path, delete_src=True, **preset.options)
     return True
 
 

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -478,7 +478,7 @@ class Youtube2Zim(object):
         options = {
             "cachedir": self.videos_dir,
             "writethumbnail": True,
-            "write_all_thumbnails": True,
+            "write_all_thumbnails": False,
             "writesubtitles": True,
             "allsubtitles": True,
             "subtitlesformat": "vtt",
@@ -592,10 +592,10 @@ class Youtube2Zim(object):
         preset = {"mp4": VideoMp4Low}.get(self.video_format, VideoWebmLow)()
         options_copy = options.copy()
         video_location = options_copy["y2z_videos_dir"].joinpath(video_id)
+        video_path = video_location.joinpath(f"video.{self.video_format}")
 
         if self.s3_storage:
             s3_key = f"{self.video_format}/{self.video_quality}/{video_id}"
-            video_path = video_location.joinpath(f"video.{self.video_format}")
             logger.debug(
                 f"Attempting to download video file for {video_id} from cache..."
             )
@@ -634,10 +634,10 @@ class Youtube2Zim(object):
         preset = WebpHigh()
         options_copy = options.copy()
         video_location = options_copy["y2z_videos_dir"].joinpath(video_id)
+        thumbnail_path = video_location.joinpath("video.webp")
 
         if self.s3_storage:
             s3_key = f"thumbnails/high/{video_id}"
-            thumbnail_path = video_location.joinpath("video.webp")
             logger.debug(
                 f"Attempting to download thumbnail for {video_id} from cache..."
             )

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -626,7 +626,7 @@ class Youtube2Zim(object):
             FileNotFoundError,
             subprocess.CalledProcessError,
         ) as exc:
-            logger.error("Video file for {video_id} could not be downloaded")
+            logger.error(f"Video file for {video_id} could not be downloaded")
             logger.debug(exc)
             return False
         else:  # upload to cache only if everything went well
@@ -669,7 +669,7 @@ class Youtube2Zim(object):
             FileNotFoundError,
             subprocess.CalledProcessError,
         ) as exc:
-            logger.error("Thumbnail for {video_id} could not be downloaded")
+            logger.error(f"Thumbnail for {video_id} could not be downloaded")
             logger.debug(exc)
             return False
         else:  # upload to cache only if everything went well
@@ -698,7 +698,7 @@ class Youtube2Zim(object):
             if self.download_video(video_id, options) and self.download_thumbnail(
                 video_id, options
             ):
-                self.download_subtitles(video_id)
+                self.download_subtitles(video_id, options)
                 succeeded.append(video_id)
             else:
                 failed.append(video_id)

--- a/youtube2zim/templates/article.html
+++ b/youtube2zim/templates/article.html
@@ -14,6 +14,8 @@
         <script src="assets/ogvjs/ogv-support.js"></script>
         <script src="assets/ogvjs/ogv.js"></script>
         <script src="assets/videojs-ogvjs.js"></script>
+        <script src="assets/polyfills.js"></script>
+        <script src="assets/webp-hero.bundle.js"></script>
     </head>
     <body>
         <div id="content">
@@ -22,7 +24,7 @@
             <p id="title">{{ title }}</p>
             <video  class="video-js vjs-default-skin"
                     id="video_container"
-                    poster="videos/{{ video_id }}/video.jpg"
+                    poster="videos/{{ video_id }}/video.webp"
                     width="480px" height="270px"
                     data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
                 <source src="videos/{{ video_id }}/video.{{ video_format }}" type="video/{{ video_format }}" />{% if subtitles %}
@@ -34,5 +36,21 @@
             </div>
             <div id="date">{{ date }}</div>
         </div>
+        <script>
+            $(document).ready(function() {
+                webpHero.detectWebpSupport().then(function (support_webp){
+                    if (!support_webp) {
+                        console.log("no WebP support, polyfilling.");
+                        // un-hide ogvjs-poster so the polyfill can transform it
+                        $(".ogvjs-poster").css("visibility", "");
+                        // hide video-js poster (which uses background-image)
+                        $(".vjs-poster").css("display", "none");
+
+                        let webpMachine = new webpHero.WebpMachine();
+                        webpMachine.polyfillDocument();
+                    }
+                });
+            });
+        </script>
     </body>
 </html>

--- a/youtube2zim/templates/assets/app.js
+++ b/youtube2zim/templates/assets/app.js
@@ -107,7 +107,7 @@ function refreshVideos(pageData) {
       a.className = 'nostyle'
 
       var img = document.createElement('img');
-      img.src = ZIM_IMG_NS + "videos/" + video['id'] + "/video.jpg";
+      img.src = ZIM_IMG_NS + "videos/" + video['id'] + "/video.webp";
 
       var title = document.createElement('p');
       title.id = 'title';
@@ -140,7 +140,7 @@ function firstVideo(video) {
                'data-setup=\'{"techOrder": ["html5", "ogvjs"], ' + 
                             '"ogvjs": {"base": "assets/ogvjs"}, "autoplay": false, ' +
                                       '"preload": true, "controls": true, "controlBar": {"pictureInPictureToggle": false}}\'' +
-               'poster="' + ZIM_IMG_NS + 'videos/' + video['id'] + '/video.jpg">' +
+               'poster="' + ZIM_IMG_NS + 'videos/' + video['id'] + '/video.webp">' +
             '<source src="' + ZIM_IMG_NS + 'videos/' + video['id'] + '/video.{{ video_format }}" ' +
                     'type="video/{{ video_format }}" />' + subtitles + '</video>' +
             '<div id="video-details">' +

--- a/youtube2zim/templates/home.html
+++ b/youtube2zim/templates/home.html
@@ -17,6 +17,8 @@
     <script src="assets/ogvjs/ogv-support.js"></script>
     <script src="assets/ogvjs/ogv.js"></script>
     <script src="assets/videojs-ogvjs.js"></script>
+    <script src="assets/polyfills.js"></script>
+    <script src="assets/webp-hero.bundle.js"></script>
   </head>
   <body>
     <div class="container">
@@ -57,5 +59,16 @@
   <script src="assets/data.js"></script>
   <script src="assets/db.js"></script>
   <script src="assets/app.js"></script>
+  <script>
+    $(document).ready(function() {
+      webpHero.detectWebpSupport().then(function (support_webp){
+          if (!support_webp) {
+              console.log("no WebP support, polyfilling.");
+              let webpMachine = new webpHero.WebpMachine();
+              webpMachine.polyfillDocument();
+          }
+      });
+  });
+  </script>
 </body>
 </html>

--- a/youtube2zim/youtube.py
+++ b/youtube2zim/youtube.py
@@ -5,7 +5,7 @@
 import requests
 from dateutil import parser as dt_parser
 from zimscraperlib.download import save_file
-from zimscraperlib.imaging import resize_image
+from zimscraperlib.image.transformation import resize_image
 
 from .constants import logger, YOUTUBE, USER, CHANNEL, PLAYLIST
 from .utils import save_json, load_json, get_slug


### PR DESCRIPTION
This allows using WebP for thumbnails with optimization and S3 cache support. Also applies the same CSS tweaks (alongwith webp-hero) and fixes #91 as a result.

This does the following chages -
- thumbnail convertion logic is moved from `processing.py` to `download_video_files_batch()` in `scraper.py ` in the form of a function `process_thumbnail()`.
- templates are updated to use WebP thumbnails
- thumbnails are now optimized and uploaded to cache