### PR TITLE
Unset `metadata_from` + rollback to Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-bookworm
+FROM python:3.10-bookworm
 LABEL org.opencontainers.image.source https://github.com/openzim/youtube
 
 # Install necessary packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ build-backend = "hatchling.build"
 name = "youtube2zim"
 authors = [{ name = "Kiwix", email = "dev@kiwix.org" }]
 keywords = ["kiwix", "zim", "offline", "youtube"]
-requires-python = ">=3.11"
+requires-python = ">=3.10,<3.11"
 description = "Make ZIM file from a Youtube channel, user or playlist(s)"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.10",
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
 ]
 dependencies = [
@@ -222,5 +222,5 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 include = ["src", "tests", "tasks.py"]
 exclude = [".env/**", ".venv/**", "src/youtube2zim/templates", ".hatch"]
 extraPaths = ["src"]
-pythonVersion = "3.11"
+pythonVersion = "3.10"
 typeCheckingMode = "basic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ exclude = ["/.github"]
 
 [tool.hatch.build.hooks.custom]
 path = "hatch_build.py"
-dependencies = ["zimscraperlib==3.1.1"]
+dependencies = ["zimscraperlib>=2.0.0,<2.1.0"]
 
 [tool.hatch.envs.default]
 features = ["dev"]

--- a/src/youtube2zim/playlists/scraper.py
+++ b/src/youtube2zim/playlists/scraper.py
@@ -46,10 +46,11 @@ class YoutubeHandler:
 
         self.build_dir = pathlib.Path(tempfile.mkdtemp())
 
-        # metadata_from JSON file
-        self.metadata_from = (
-            pathlib.Path(self.metadata_from) if self.metadata_from else None
-        )
+        self.metadata_from = None
+        # metadata_from JSON file is broken for now
+        # self.metadata_from = (
+        #     pathlib.Path(self.metadata_from) if self.metadata_from else None
+        # )
         self.metadata = {}  # custom metadata holder
 
         # update youtube credentials store


### PR DESCRIPTION
# Rationale
- we should release a 2.2.0 asap with current `main` status since this would solve #184 (which is blocking all scrapers) but:
  - there is a strange error about `metadata_from` when running the scraper with `youtube2zim-playlists` ; it is obviously harmless to simply disable this code since it is not possible to setup the `metadata_from` which current code anyway
  - `main` is in fact not correct, it is using Python 3.11 while we are still at `zimscraperlib` 2.0 which supports only Python 3.10 (don't know why this is not causing a problem in Docker build + why it does not raised a red flag before)

# Changes
- set `metadata_from` to always be `None` for now
- rollback to Python 3.10
- align `zimscraperlib` version constraints in hatch dependencies with project version (just in case)