### PR TITLE
Finish removal of locale related code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update dependencies in pyproject.toml (pydantic, pyhumps, python-slugify)
 - Update scraper to generate JSON files for `zimui` (#212)
 - Remove old UI files and methods: template files (home.html, article.html) and `make_html_files` method in scraper.py
-- Remove broken locale folder and files used for translation; translation will be restored with #222
+- Remove `--locale` arg, broken locale folder, files used for translation; translation will be restored with #222
 - Create "Videos" and "Playlists" tabs for homepage in new Vue.js UI (#213, #214)
 
 ## [2.3.0] - 2024-05-22

--- a/scraper/src/youtube2zim/entrypoint.py
+++ b/scraper/src/youtube2zim/entrypoint.py
@@ -108,13 +108,6 @@ def main():
     )
 
     parser.add_argument(
-        "--locale",
-        help="Locale name to use for translations (if avail) and time representations. "
-        "Defaults to --language or English.",
-        dest="locale_name",
-    )
-
-    parser.add_argument(
         "--title",
         help="Custom title for your project and ZIM. "
         "Default to Channel name (of first video if playlists)",

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -10,7 +10,6 @@
 import concurrent.futures
 import datetime
 import functools
-import locale
 import os
 import re
 import shutil
@@ -24,7 +23,7 @@ from kiwixstorage import KiwixStorage
 from pif import get_public_ip
 from zimscraperlib.download import stream_file
 from zimscraperlib.fix_ogvjs_dist import fix_source_dir
-from zimscraperlib.i18n import NotFound, get_language_details, setlocale
+from zimscraperlib.i18n import NotFound, get_language_details
 from zimscraperlib.image.convertion import convert_image
 from zimscraperlib.image.presets import WebpHigh
 from zimscraperlib.image.probing import get_colors, is_hex_color
@@ -102,7 +101,6 @@ class Youtube2Zim:
         keep_build_dir,
         max_concurrency,
         language,
-        locale_name,
         tags,
         dateafter,
         use_any_optimized_version,
@@ -189,17 +187,6 @@ class Youtube2Zim:
         self.use_any_optimized_version = use_any_optimized_version
         self.video_quality = "low" if self.low_quality else "high"
         self.s3_storage = None
-
-        # set and record locale for translations
-        locale_name = locale_name or get_language_details(self.language)["iso-639-1"]
-        try:
-            self.locale = setlocale(ROOT_DIR, locale_name)
-        except locale.Error:
-            logger.error(
-                f"No locale for {locale_name}. Use --locale to specify it. "
-                "defaulting to en_US"
-            )
-            self.locale = setlocale(ROOT_DIR, "en")
 
     @property
     def root_dir(self):


### PR DESCRIPTION
This PR removes the `--locale` argument from entrypoint.py and some code from scraper.py using the `setlocale` method.

- Closes #226