### PR TITLE
Upgrade to scraperlib v3.4.0 to use VP9

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v3
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build-scraper:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   -   id: trailing-whitespace
   -   id: end-of-file-fixer
@@ -11,11 +11,11 @@ repos:
   hooks:
   -   id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.4
+  rev: v0.4.10
   hooks:
   - id: ruff
 - repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.363
+  rev: v1.1.368
   hooks:
   - id: pyright
     name: pyright (system)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updgrade to zimscraperlib 3.4.0 (including **new webm encoder presets to migrate to VP9 instead of VP8**) (#204)
+
 ## [2.3.0] - 2024-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Youtube2zim
 `youtube2zim` allows you to create a [ZIM file](https://openzim.org)
 from a Youtube Channel/Username or one-or-more Playlists.
 
-It downloads the video (`webm` or `mp4` extension – optionnaly
+It downloads the video (`webm` or `mp4` extension – optionaly
 recompress them in lower-quality, smaller size), the thumbnails, the
 subtitles and the authors' profile pictures ; then, it create a static
 HTML files folder of it before creating a ZIM off of it.
 
-This project adheres to openZIM's Contribution Guidelines.
+`youtube2zim` adheres to openZIM's [Contribution Guidelines](https://github.com/openzim/overview/wiki/Contributing).
 
-This project has implemented openZIM's Python bootstrap, conventions and policies v1.0.1.
+`youtube2zim` has implemented openZIM's [Python bootstrap, conventions and policies](https://github.com/openzim/_python-bootstrap/docs/Policy.md) **v1.0.2**.
 
 Requirements
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ requires-python = ">=3.12,<3.13"
 description = "Make ZIM file from a Youtube channel, user or playlist(s)"
 readme = "README.md"
 dependencies = [
-  "python-slugify==3.0.3",
+  "python-slugify==8.0.4",
   "yt-dlp",                      # youtube-dl should be updated as frequently as possible
   "python-dateutil==2.9.0.post0",
   "jinja2==3.1.4",
-  "zimscraperlib==3.3.2",
-  "requests==2.32.0",
-  "kiwixstorage==0.8.3",
+  "zimscraperlib==3.4.0",
+  "requests==2.32.3",
+  "kiwixstorage==0.9.0",
   "pif==0.8.2",
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
@@ -27,13 +27,23 @@ kind = "scraper"
 additional-keywords = ["youtube"]
 
 [tool.hatch.build.hooks.openzim-build]
-dependencies = [ "zimscraperlib==3.3.2"] # required for fix_ogv_dist
+dependencies = [ "zimscraperlib==3.4.0"] # required for fix_ogv_dist
 
 [project.optional-dependencies]
-scripts = ["invoke==2.2.0"]
-lint = ["black==24.4.2", "ruff==0.4.4"]
-check = ["pyright==1.1.363"]
-test = ["pytest==8.1.1", "coverage==7.4.4"]
+scripts = [
+  "invoke==2.2.0",
+]
+lint = [
+  "black==24.4.2",
+  "ruff==0.4.10",
+]
+check = [
+  "pyright==1.1.368",
+]
+test = [
+  "pytest==8.2.2",
+  "coverage==7.5.3",
+]
 dev = [
   "pre-commit==3.7.1",
   "debugpy==1.8.1",

--- a/tasks.py
+++ b/tasks.py
@@ -24,6 +24,7 @@ def report_cov(ctx: Context, *, html: bool = False):
     """report coverage"""
     ctx.run("coverage combine", warn=True, pty=use_pty)
     ctx.run("coverage report --show-missing", pty=use_pty)
+    ctx.run("coverage xml", pty=use_pty)
     if html:
         ctx.run("coverage html", pty=use_pty)
 


### PR DESCRIPTION
Partial implementation of #235 

- partial because this PR is an update on the `v2` branch since v3 is not yet ready
- this also needs to be backported to `main` branch as well
- tests done
  - run again the scraper => all videos are reencoded with VP9 and reuploaded to cache
  - run again the scraper a second time => all videos are downloaded from cache and are encoded with VP9
- also implement bootstrap v1.0.2 (fixes to code coverage upload)
