### PR TITLE
Add playlist panel to video player page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create video player page in new Vue.js UI (#215)
 - Add support for variable playback speed in video player (#174)
 - Updgrade to zimscraperlib 3.4.0 (including **new webm encoder presets to migrate to VP9 instead of VP8**) (#204)
+- Add playlist panel for playing videos in a playlist (#216)
 
 ## [2.3.0] - 2024-05-22
 

--- a/zimui/cypress/e2e/video_player_page.cy.ts
+++ b/zimui/cypress/e2e/video_player_page.cy.ts
@@ -22,4 +22,32 @@ describe('video player page', () => {
     cy.contains('.video-channel', 'openZIM_testing')
     cy.contains('.video-description', 'This is a short video of a timelapse.')
   })
+
+  it('loads the playlist panel', () => {
+    cy.intercept('GET', '/playlists.json', { fixture: 'channel/playlists.json' }).as('getPlaylists')
+    cy.intercept('GET', '/playlists/timelapses-QgGI.json', {
+      fixture: 'channel/playlists/timelapses-QgGI.json'
+    }).as('getPlaylist')
+    cy.intercept('GET', '/videos/timelapse-9Tgo.json', {
+      fixture: 'channel/videos/timelapse-9Tgo.json'
+    }).as('getVideo1')
+    cy.intercept('GET', '/videos/cloudy_sky_time_lapse-k02q.json', {
+      fixture: 'channel/videos/cloudy_sky_time_lapse-k02q.json'
+    }).as('getVideo2')
+
+    cy.contains('.v-btn__content', 'Playlists').click()
+    cy.wait('@getPlaylists')
+
+    cy.contains('.v-card-title ', 'Timelapses').click()
+    cy.url().should('include', 'watch/timelapse-9Tgo?list=timelapses-QgGI')
+
+    cy.wait('@getPlaylist')
+    cy.wait('@getVideo1')
+
+    cy.contains('Timelapses').should('be.visible')
+    cy.contains('openZIM_testing - 1/2').should('be.visible')
+
+    cy.contains('Cloudy Sky Time Lapse').click()
+    cy.contains('openZIM_testing - 2/2').should('be.visible')
+  })
 })

--- a/zimui/cypress/fixtures/channel/playlists/timelapses-QgGI.json
+++ b/zimui/cypress/fixtures/channel/playlists/timelapses-QgGI.json
@@ -1,0 +1,32 @@
+{
+  "id": "PLMK6hZr9PcsjcF5mnaQk8Fi-xnb0AQgGI",
+  "author": {
+    "channelId": "UC8elThf5TGMpQfQc_VE917Q",
+    "channelTitle": "openZIM_testing",
+    "channelDescription": "",
+    "channelJoinedDate": "2024-06-04T13:30:16.232286Z",
+    "profilePath": "channels/UC8elThf5TGMpQfQc_VE917Q/profile.jpg",
+    "bannerPath": "channels/UC8elThf5TGMpQfQc_VE917Q/banner.jpg"
+  },
+  "title": "Timelapses",
+  "description": "",
+  "publicationDate": "2024-06-04T15:04:46Z",
+  "thumbnailPath": "videos/9TgosbGRsTk/video.webp",
+  "videos": [
+    {
+      "slug": "timelapse-9Tgo",
+      "id": "9TgosbGRsTk",
+      "title": "Timelapse",
+      "thumbnailPath": "videos/9TgosbGRsTk/video.webp",
+      "duration": "PT11S"
+    },
+    {
+      "slug": "cloudy_sky_time_lapse-k02q",
+      "id": "k02qXOcCrbo",
+      "title": "Cloudy Sky Time Lapse",
+      "thumbnailPath": "videos/k02qXOcCrbo/video.webp",
+      "duration": "PT36S"
+    }
+  ],
+  "videosCount": 2
+}

--- a/zimui/cypress/fixtures/channel/videos/cloudy_sky_time_lapse-k02q.json
+++ b/zimui/cypress/fixtures/channel/videos/cloudy_sky_time_lapse-k02q.json
@@ -1,0 +1,19 @@
+{
+  "id": "k02qXOcCrbo",
+  "title": "Cloudy Sky Time Lapse",
+  "description": "Free Footage 4K video no copyright\n\nTime-Lapse Nature Video playlist:\nhttps://www.youtube.com/playlist?list=PLMxIGFJY9lsL87ewazOepnrtBhz2IPKpz\n\nSummer Nature Video playlist:\nhttps://www.youtube.com/playlist?list=PLMxIGFJY9lsI1bQCDl0bD4_S9mtRYcPKq\n\nAutumn Nature Video playlist:\nhttps://www.youtube.com/playlist?list=PLMxIGFJY9lsII_v8B4nfZbJQrd-eFMwH_\n\nWinter Nature Video playlist:\nhttps://www.youtube.com/playlist?list=PLMxIGFJY9lsJqYFTFeE6PQWOL-2S9ypUG\n\nWalking Nature Videos\nhttps://www.youtube.com/playlist?list=PLMxIGFJY9lsJ1sbHWr3jJIsHe1wrYzcmI\n\nMacBook Green Screen\nhttps://www.youtube.com/playlist?list=PLMxIGFJY9lsJFC2wqMtGGnFGZ_K9hrks7\n\nMain YT channel:\nhttps://www.youtube.com/@skrava\n\n_______\nShot with a GoPro 11 Black\n\n__________________\nMy social network\n\nInstagram - https://www.instagram.com/skrava.creater/\nThreads - https://www.strava.com/athletes/90413635\n\n__________________\nYou can support to me\n\nPayPal - sergey3462kravchenko@gmail.com\n__________________\n\n#footagefree #footagenocopyright #footage4k  #gopro4k",
+  "author": {
+    "channelId": "UCYkQBdQT7nZoiM9jknekphQ",
+    "channelTitle": "Serhii Kravchenko / Footage",
+    "channelDescription": "On this channel, you will find footage and time-lapse videos of nature available for free use. Your support helps the channel grow.\n\nEmail - sergey3462kravchenko@gmail.com",
+    "channelJoinedDate": "2023-07-03T08:18:35.638964Z",
+    "profilePath": "channels/UCYkQBdQT7nZoiM9jknekphQ/profile.jpg",
+    "bannerPath": "channels/UCYkQBdQT7nZoiM9jknekphQ/banner.jpg"
+  },
+  "publicationDate": "2023-07-24T15:25:19Z",
+  "videoPath": "videos/k02qXOcCrbo/video.webm",
+  "thumbnailPath": "videos/k02qXOcCrbo/video.webp",
+  "subtitlePath": null,
+  "subtitleList": [],
+  "duration": "PT36S"
+}

--- a/zimui/src/components/common/ErrorDisplay.vue
+++ b/zimui/src/components/common/ErrorDisplay.vue
@@ -6,13 +6,15 @@ const main = useMainStore()
 </script>
 
 <template>
-  <div class="error-container h-screen d-flex flex-column justify-center">
-    <div>
-      <img :src="errImage" class="error-image" />
-      <p class="error-text">{{ main.errorMessage }}</p>
-      <p class="error-text">{{ main.errorDetails }}</p>
-    </div>
-  </div>
+  <v-empty-state
+    headline="Something went wrong"
+    :title="main.errorMessage"
+    :text="main.errorDetails"
+    class="h-screen"
+    :image="errImage"
+  >
+    <v-btn href="/" variant="tonal">Go back home</v-btn>
+  </v-empty-state>
 </template>
 
 <style scoped>

--- a/zimui/src/components/playlist/panel/PlaylistPanel.vue
+++ b/zimui/src/components/playlist/panel/PlaylistPanel.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { computed, nextTick, watch } from 'vue'
+import { useDisplay } from 'vuetify'
+
+import type { Playlist } from '@/types/Playlists'
+import { LoopOptions } from '@/types/Playlists'
+
+import PlaylistPanelItem from './PlaylistPanelItem.vue'
+
+const { smAndDown } = useDisplay()
+
+const props = defineProps<{
+  playlist: Playlist
+  videoSlug: string
+  playlistSlug: string
+  currentVideoIndex: number
+  showToggle: boolean
+  loop: LoopOptions
+  shuffle: boolean
+}>()
+
+// Calculate the height of the playlist panel container
+const panelContainerHeight = computed<string>(() => {
+  if (props.playlist.videos.length > 5) {
+    if (smAndDown.value) {
+      return '350px'
+    }
+    return '500px'
+  }
+  return '100%'
+})
+
+watch(
+  () => props.videoSlug,
+  () => {
+    nextTick(() => {
+      scrollToCurrentVideo()
+    })
+  }
+)
+
+// Scroll to the current video in the playlist panel
+const scrollToCurrentVideo = () => {
+  const currentVideoId = `video-item-${props.currentVideoIndex}`
+  const currentVideoElement = document.getElementById(currentVideoId)
+  const panelContainer = document.getElementById('panel-items-container')
+  if (currentVideoElement && panelContainer) {
+    panelContainer.scrollTop = currentVideoElement.offsetTop - panelContainer.offsetTop
+  }
+}
+
+const emit = defineEmits(['shuffle', 'loop', 'hide-panel'])
+</script>
+
+<template>
+  <v-card class="border-thin rounded-lg" flat>
+    <v-card-item class="border-b-thin bg-grey-lighten-5 px-2">
+      <v-row class="px-2">
+        <v-col :cols="showToggle ? 9 : 12">
+          <v-card-title class="panel-title">{{ props.playlist.title }}</v-card-title>
+          <v-card-subtitle class="panel-channel text-caption">
+            <span class="font-weight-medium">
+              {{ props.playlist.author.channelTitle }}
+            </span>
+            - {{ props.currentVideoIndex + 1 }}/{{ props.playlist.videos.length }}
+          </v-card-subtitle>
+        </v-col>
+        <v-col v-if="showToggle" cols="3" class="d-flex align-center justify-end">
+          <v-btn
+            class="pa-2"
+            icon="mdi-close"
+            size="md"
+            variant="text"
+            @click="() => emit('hide-panel')"
+          ></v-btn>
+        </v-col>
+      </v-row>
+      <v-row dense no-gutters>
+        <v-col>
+          <v-btn
+            class="pa-2"
+            size="md"
+            variant="text"
+            :icon="loop === LoopOptions.loopVideo ? 'mdi-repeat-once' : 'mdi-repeat'"
+            :color="loop === LoopOptions.off ? 'grey' : 'grey-darken-3'"
+            :title="
+              loop === LoopOptions.off
+                ? 'Loop playlist'
+                : loop === LoopOptions.loopPlaylist
+                ? 'Loop video'
+                : 'Turn off loop'
+            "
+            flat
+            @click="() => emit('loop')"
+          >
+          </v-btn>
+          <v-btn
+            class="pa-2"
+            size="md"
+            variant="text"
+            icon="mdi-shuffle"
+            :color="shuffle ? 'grey-darken-3' : 'grey'"
+            title="Shuffle Playlist"
+            flat
+            @click="() => emit('shuffle')"
+          ></v-btn>
+        </v-col>
+      </v-row>
+    </v-card-item>
+
+    <v-card-item class="pa-0">
+      <div id="panel-items-container" :style="{ height: panelContainerHeight }">
+        <playlist-panel-item
+          v-for="(item, index) in props.playlist.videos"
+          :id="`video-item-${index}`"
+          :key="item.slug"
+          :video="item"
+          :order="index + 1"
+          :selected="item.slug === props.videoSlug"
+          :playlist-slug="props.playlistSlug"
+        ></playlist-panel-item>
+      </div>
+    </v-card-item>
+  </v-card>
+</template>
+
+<style scoped>
+#panel-items-container {
+  overflow: auto;
+  scroll-behavior: smooth;
+}
+</style>

--- a/zimui/src/components/playlist/panel/PlaylistPanelItem.vue
+++ b/zimui/src/components/playlist/panel/PlaylistPanelItem.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { VideoPreview } from '@/types/Videos'
+import { formatTimestamp, truncateText } from '@/utils/format-utils'
+import { useDisplay } from 'vuetify'
+
+const { smAndDown } = useDisplay()
+
+const props = defineProps<{
+  video: VideoPreview
+  order: number
+  selected: boolean
+  playlistSlug: string
+}>()
+
+// Set the maximum length of the title based on the screen size
+const titleLength = computed<number>(() => {
+  if (smAndDown.value) {
+    return 60
+  } else {
+    return 80
+  }
+})
+
+// Truncate the title if it's too long
+const truncatedTitle = computed<string>(() => {
+  return truncateText(props.video.title, titleLength.value)
+})
+</script>
+
+<template>
+  <v-card
+    class="py-2 rounded-0"
+    :variant="selected ? 'tonal' : 'flat'"
+    flat
+    :to="{
+      name: 'watch-video',
+      params: { slug: props.video.slug },
+      query: { list: playlistSlug }
+    }"
+  >
+    <v-row dense>
+      <v-col cols="4" md="5" xl="4">
+        <div class="d-flex position-relative">
+          <div class="d-flex align-center justify-center text-caption">
+            <v-icon v-if="selected" class="mx-1" size="15"> mdi-play </v-icon>
+            <span v-else class="mx-2">{{ order }}</span>
+          </div>
+          <v-img
+            class="border-thin rounded-lg"
+            :src="props.video.thumbnailPath"
+            min-width="50"
+            max-width="250"
+          ></v-img>
+          <v-chip
+            class="bg-black opacity-80 position-absolute bottom-0 right-0 pa-1 mb-1 mr-1 text-caption"
+            size="xs"
+            rounded="lg"
+          >
+            {{ formatTimestamp(props.video.duration) }}
+          </v-chip>
+        </div>
+      </v-col>
+      <v-col cols="8" md="7" xl="8">
+        <v-card-title class="text-body-2 text-wrap py-0 pr-2" :title="props.video.title">{{
+          truncatedTitle
+        }}</v-card-title>
+      </v-col>
+    </v-row>
+  </v-card>
+</template>

--- a/zimui/src/components/playlist/panel/PlaylistPanelPreview.vue
+++ b/zimui/src/components/playlist/panel/PlaylistPanelPreview.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { Playlist } from '@/types/Playlists'
+
+const props = defineProps<{
+  playlist: Playlist
+  currentVideoIndex: number
+}>()
+
+const emit = defineEmits(['click'])
+</script>
+
+<template>
+  <v-card
+    class="mx-auto border-thin rounded-lg"
+    prepend-icon="mdi-playlist-play"
+    append-icon="mdi-chevron-down"
+    link
+    flat
+    color="grey-lighten-5"
+    @click="() => emit('click')"
+  >
+    <template #title>
+      <v-card-title>{{ props.playlist.title }}</v-card-title>
+    </template>
+    <template #subtitle>
+      <v-card-subtitle class="text-caption">
+        <span class="font-weight-medium">
+          {{ props.playlist.author.channelTitle }}
+        </span>
+        - {{ props.currentVideoIndex + 1 }}/{{ props.playlist.videos.length }}
+      </v-card-subtitle>
+    </template>
+  </v-card>
+</template>

--- a/zimui/src/components/video/player/VideoChannelInfo.vue
+++ b/zimui/src/components/video/player/VideoChannelInfo.vue
@@ -24,10 +24,12 @@ const props = defineProps({
 <template>
   <v-row>
     <v-col cols="6" class="d-flex align-center py-2">
-      <v-avatar size="50" class="border-thin">
-        <v-img :src="props.profilePath" />
-      </v-avatar>
-      <span class="video-channel ml-2 font-weight-medium">{{ props.channelTitle }}</span>
+      <router-link :to="{ name: 'home' }">
+        <v-avatar size="50" class="border-thin">
+          <v-img :src="props.profilePath" />
+        </v-avatar>
+        <span class="video-channel ml-2 font-weight-medium">{{ props.channelTitle }}</span>
+      </router-link>
     </v-col>
     <v-col cols="6" class="d-flex justify-end align-center">
       <about-dialog-button
@@ -38,3 +40,9 @@ const props = defineProps({
     </v-col>
   </v-row>
 </template>
+
+<style scoped>
+.video-channel {
+  color: initial;
+}
+</style>

--- a/zimui/src/router/index.ts
+++ b/zimui/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHashHistory } from 'vue-router'
 
 import HomeView from '../views/HomeView.vue'
 import VideoPlayerView from '../views/VideoPlayerView.vue'
+import NotFoundView from '../views/NotFoundView.vue'
 
 import VideosTab from '@/components/channel/tabs/VideosTab.vue'
 import PlaylistsTab from '@/components/channel/tabs/PlaylistsTab.vue'
@@ -31,7 +32,8 @@ const router = createRouter({
       path: '/watch/:slug',
       name: 'watch-video',
       component: VideoPlayerView
-    }
+    },
+    { path: '/:pathMatch(.*)*', name: 'not-found', component: NotFoundView }
   ],
   scrollBehavior() {
     return { top: 0, behavior: 'smooth' }

--- a/zimui/src/stores/main.ts
+++ b/zimui/src/stores/main.ts
@@ -49,6 +49,7 @@ export const useMainStore = defineStore('main', {
       return axios.get(`./playlists/${title}.json`).then(
         (response) => {
           this.isLoading = false
+          this.checkResponseObject(response.data, 'Playlist not found.')
           return response.data as Playlist
         },
         (error) => {
@@ -87,6 +88,7 @@ export const useMainStore = defineStore('main', {
       return axios.get(`./videos/${slug}.json`).then(
         (response) => {
           this.isLoading = false
+          this.checkResponseObject(response.data, 'Video not found.')
           const video: Video = response.data
           return video
         },
@@ -98,6 +100,14 @@ export const useMainStore = defineStore('main', {
           }
         }
       )
+    },
+    checkResponseObject(response: unknown, msg: string = '') {
+      if (response === null || typeof response !== 'object') {
+        if (msg !== '') {
+          this.errorDetails = msg
+        }
+        throw new Error('Invalid response object.')
+      }
     },
     handleAxiosError(error: AxiosError<object>) {
       if (axios.isAxiosError(error) && error.response) {

--- a/zimui/src/stores/main.ts
+++ b/zimui/src/stores/main.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import axios, { AxiosError } from 'axios'
 import type { Channel } from '@/types/Channel'
-import type { Playlist, Playlists } from '@/types/Playlists'
+import type { LoopOptions, Playlist, Playlists } from '@/types/Playlists'
 import type { Video } from '@/types/Videos'
 
 export type RootState = {
@@ -9,6 +9,8 @@ export type RootState = {
   isLoading: boolean
   errorMessage: string
   errorDetails: string
+  loop: LoopOptions
+  shuffle: boolean
 }
 
 export const useMainStore = defineStore('main', {
@@ -17,7 +19,9 @@ export const useMainStore = defineStore('main', {
       channel: null,
       isLoading: false,
       errorMessage: '',
-      errorDetails: ''
+      errorDetails: '',
+      loop: 'off',
+      shuffle: false
     }) as RootState,
   getters: {},
   actions: {
@@ -130,6 +134,12 @@ export const useMainStore = defineStore('main', {
     },
     setErrorMessage(message: string) {
       this.errorMessage = message
+    },
+    setLoop(value: LoopOptions) {
+      this.loop = value
+    },
+    setShuffle(value: boolean) {
+      this.shuffle = value
     }
   }
 })

--- a/zimui/src/types/Playlists.ts
+++ b/zimui/src/types/Playlists.ts
@@ -23,3 +23,9 @@ export interface PlaylistPreview {
 export interface Playlists {
   playlists: PlaylistPreview[]
 }
+
+export enum LoopOptions {
+  off = 'off',
+  loopVideo = 'loop-video',
+  loopPlaylist = 'loop-playlist'
+}

--- a/zimui/src/views/NotFoundView.vue
+++ b/zimui/src/views/NotFoundView.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import notFoundImg from '@/assets/images/dead-kiwix.png'
+</script>
+
+<template>
+  <v-empty-state
+    headline="Whoops, 404"
+    title="Page not found"
+    text="The page you were looking for does not exist"
+    class="h-screen"
+    :image="notFoundImg"
+  ></v-empty-state>
+</template>


### PR DESCRIPTION
This PR adds a playlist panel to the video player page.
- Added a playlist panel that displays the videos in a playlist (Playlist is loaded through the `list` query parameter in URL)
- Added player control buttons to loop (Loop video/playlist) and shuffle playlist.
- Updated error handling for unknown videos, playlists and paths.

Screenshot:
<img width="1425" alt="image" src="https://github.com/openzim/youtube/assets/56271899/b6de4af7-0add-4efb-b09b-474c4fb54d80">

Closes #216