### PR TITLE
Fix new line rendering in descriptions in zimui

### DIFF
--- a/zimui/src/components/channel/AboutDialogButton.vue
+++ b/zimui/src/components/channel/AboutDialogButton.vue
@@ -41,7 +41,7 @@ const formattedDate = computed(() => {
           </v-col>
           <v-col cols="12">
             <p class="text-h6">Description</p>
-            <p>{{ props.description || notAvailable }}</p>
+            <p class="text-pre-wrap">{{ props.description || notAvailable }}</p>
           </v-col>
           <v-col cols="12">
             <p class="text-h6">Joined Date</p>

--- a/zimui/src/components/video/player/VideoDescription.vue
+++ b/zimui/src/components/video/player/VideoDescription.vue
@@ -12,7 +12,7 @@ const props = defineProps({
     <v-col>
       <v-card class="border-thin py-2" rounded="lg" flat>
         <v-card-title class="text-subtitle-1 font-weight-medium">Description</v-card-title>
-        <v-card-text class="video-description">{{ props.description }}</v-card-text>
+        <v-card-text class="video-description text-pre-wrap">{{ props.description }}</v-card-text>
       </v-card>
     </v-col>
   </v-row>

--- a/zimui/src/views/PlaylistView.vue
+++ b/zimui/src/views/PlaylistView.vue
@@ -111,7 +111,10 @@ onMounted(() => {
             <v-icon icon="mdi-arrow-left" start></v-icon>
             Back to Playlists
           </v-btn>
-          <p v-if="playlist.description !== ''" class="playlist-description text-caption mt-4">
+          <p
+            v-if="playlist.description !== ''"
+            class="playlist-description text-caption text-pre-wrap mt-4"
+          >
             {{ playlist.description }}
           </p>
         </v-card>


### PR DESCRIPTION
Fix #248

Added the `text-pre-wrap` utility class from Vuetify to render new-lines in description areas in the new UI.

Before:
<img width="500" alt="image" src="https://github.com/openzim/youtube/assets/56271899/07081e70-c7eb-400d-a62d-622ba161c83a">

After:
<img width="500" alt="image" src="https://github.com/openzim/youtube/assets/56271899/e45396cc-e51a-4150-a655-2c2225556854">
