### PR TITLE
Fix side margins on tablet screens in zimui

### DIFF
--- a/zimui/src/components/channel/ChannelHeader.vue
+++ b/zimui/src/components/channel/ChannelHeader.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { useDisplay } from 'vuetify'
 
 import AboutDialogButton from '@/components/channel/AboutDialogButton.vue'
 import { useMainStore } from '@/stores/main'
 
 import profilePlaceholder from '@/assets/images/profile-placeholder.jpg'
 import bannerPlaceholder from '@/assets/images/banner-placeholder.jpg'
+
+const { mdAndDown } = useDisplay()
 
 // Fetch the channel data
 const main = useMainStore()
@@ -34,7 +37,7 @@ const tab = ref<number>(tabs[0].id)
 </script>
 
 <template>
-  <v-container class="pt-0 pt-md-4 px-0 px-md-4">
+  <v-container class="pt-0 pt-md-4 px-0 px-md-4" :fluid="mdAndDown">
     <v-card flat class="header-card border-thin border-t-0 rounded-lg">
       <!-- Banner -->
       <v-parallax
@@ -46,7 +49,7 @@ const tab = ref<number>(tabs[0].id)
       ></v-parallax>
 
       <!-- Channel Info -->
-      <v-container class="channel-info px-8">
+      <v-container class="channel-info px-8" :fluid="mdAndDown">
         <v-row>
           <v-col cols="12" md="8" class="d-flex flex-column flex-md-row align-center">
             <v-avatar size="75" class="channel-avatar border-thin">

--- a/zimui/src/components/common/ViewInfo.vue
+++ b/zimui/src/components/common/ViewInfo.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useDisplay } from 'vuetify'
+
+const { mdAndDown } = useDisplay()
+
 const props = defineProps({
   title: {
     type: String,
@@ -20,8 +24,8 @@ const props = defineProps({
 </script>
 
 <template>
-  <v-container class="py-2">
-    <v-row>
+  <v-container class="py-2 px-1" :fluid="mdAndDown">
+    <v-row dense>
       <v-col cols="7">
         <p class="d-flex align-center text-body-2 text-wrap mx-4">{{ props.title }}</p>
       </v-col>

--- a/zimui/src/components/playlist/PlaylistGrid.vue
+++ b/zimui/src/components/playlist/PlaylistGrid.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useDisplay } from 'vuetify'
 import type { PlaylistPreview } from '@/types/Playlists'
 import PlaylistCard from './PlaylistCard.vue'
+
+const { mdAndDown } = useDisplay()
 
 const props = defineProps<{
   playlists: PlaylistPreview[]
@@ -8,7 +11,7 @@ const props = defineProps<{
 </script>
 
 <template>
-  <v-container>
+  <v-container class="px-1" :fluid="mdAndDown">
     <v-row dense>
       <v-col
         v-for="playlist in props.playlists"

--- a/zimui/src/components/playlist/panel/PlaylistPanel.vue
+++ b/zimui/src/components/playlist/panel/PlaylistPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useDisplay } from 'vuetify'
 
 import type { Playlist } from '@/types/Playlists'
@@ -19,15 +19,18 @@ const props = defineProps<{
   shuffle: boolean
 }>()
 
+const windowHeight = ref(
+  window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight
+)
+
 // Calculate the height of the playlist panel container
 const panelContainerHeight = computed<string>(() => {
-  if (props.playlist.videos.length > 5) {
-    if (smAndDown.value) {
-      return '350px'
-    }
-    return '500px'
-  }
-  return '100%'
+  if (smAndDown.value) return '350px'
+
+  const panelHeight = Math.min(windowHeight.value - 150, 800)
+  const totalItemsHeight = props.playlist.videos.length * 90
+
+  return totalItemsHeight < panelHeight ? '100%' : `${panelHeight}px`
 })
 
 watch(

--- a/zimui/src/components/video/VideoGrid.vue
+++ b/zimui/src/components/video/VideoGrid.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useDisplay } from 'vuetify'
 import type { VideoPreview } from '@/types/Videos'
 import VideoCard from './VideoCard.vue'
+
+const { mdAndDown } = useDisplay()
 
 const props = defineProps<{
   videos: VideoPreview[]
@@ -8,7 +11,7 @@ const props = defineProps<{
 </script>
 
 <template>
-  <v-container>
+  <v-container class="px-1" :fluid="mdAndDown">
     <v-row dense>
       <v-col
         v-for="video in props.videos"

--- a/zimui/src/views/PlaylistView.vue
+++ b/zimui/src/views/PlaylistView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, type Ref, onMounted } from 'vue'
+import { useDisplay } from 'vuetify'
 import { useMainStore } from '@/stores/main'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -54,13 +55,15 @@ const onShuffleClick = function () {
 onMounted(() => {
   fetchPlaylistData()
 })
+
+const { mdAndDown } = useDisplay()
 </script>
 
 <template>
-  <v-container v-if="playlist">
+  <v-container v-if="playlist" :fluid="mdAndDown">
     <v-row>
       <v-spacer />
-      <v-col cols="12" md="4" xl="3" xxl="2">
+      <v-col cols="12" md="5" lg="4" xl="3" xxl="2">
         <v-card flat class="header-card rounded-lg pa-5 bg-grey-lighten-4">
           <v-img
             :lazy-src="thumbnailPlaceholder"
@@ -119,7 +122,7 @@ onMounted(() => {
           </p>
         </v-card>
       </v-col>
-      <v-col cols="12" md="8" xl="6" xxl="4">
+      <v-col cols="12" md="7" lg="8" xl="6" xxl="4">
         <v-container class="pa-0">
           <v-row dense>
             <v-col

--- a/zimui/src/views/VideoPlayerView.vue
+++ b/zimui/src/views/VideoPlayerView.vue
@@ -145,7 +145,7 @@ const onVideoEnded = () => {
   }
 }
 
-const { smAndDown } = useDisplay()
+const { smAndDown, mdAndDown } = useDisplay()
 
 const loopOptions: LoopOptions[] = [
   LoopOptions.off,
@@ -159,7 +159,7 @@ const cycleLoopOption = () => {
 </script>
 
 <template>
-  <v-container v-if="video">
+  <v-container v-if="video" :fluid="mdAndDown">
     <v-row>
       <v-spacer />
       <v-col cols="12" md="7" lg="8" xl="6">


### PR DESCRIPTION
Changes:
- Fix side margins on tablet screens so that the content fills the entire screen.
- Modify playlist panel height calculation so that the panel fits screen vertically.

Before:
<img width="400" alt="image" src="https://github.com/openzim/youtube/assets/56271899/0efa18e6-b03d-4821-9067-30ab9c82abdf">

After:
<img width="400" alt="image" src="https://github.com/openzim/youtube/assets/56271899/b1d06986-45b6-42a9-871f-0a37a11a11d4">


Fix #252