### PR TITLE
Add items to the ZIM "on the fly"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove openzim.toml and install all dependencies using Yarn (#218)
 - Validate if ZIM cannot be created at given output location (#204)
 - Add videos, subtitles, thumbnails and channel branding to the ZIM "on the fly" (#209)
-- Remove `--no-zim` CLI argument
+- Remove `--no-zim`, `--keep` CLI arguments
 
 ## [2.3.0] - 2024-05-22
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add playlist view page in new Vue.js UI (#223)
 - Add support for ogv.js in video-js player (#230)
 - Remove openzim.toml and install all dependencies using Yarn (#218)
+- Validate if ZIM cannot be created at given output location (#204)
+- Add videos, subtitles, thumbnails and channel branding to the ZIM "on the fly" (#209)
+- Remove `--no-zim` CLI argument
 
 ## [2.3.0] - 2024-05-22
 

--- a/scraper/src/youtube2zim/entrypoint.py
+++ b/scraper/src/youtube2zim/entrypoint.py
@@ -74,13 +74,6 @@ def main():
     )
 
     parser.add_argument(
-        "--no-zim",
-        help="Don't produce a ZIM file, create HTML folder only.",
-        action="store_true",
-        default=False,
-    )
-
-    parser.add_argument(
         "--zimui-dist",
         type=str,
         help=(

--- a/scraper/src/youtube2zim/entrypoint.py
+++ b/scraper/src/youtube2zim/entrypoint.py
@@ -69,8 +69,8 @@ def main():
 
     parser.add_argument(
         "--tmp-dir",
-        help="Path to create temp folder in. Used for building ZIM file. "
-        "Receives all data (storage space)",
+        help="Path to create temp folder in."
+        "Used to temporarily store downloaded files before adding to ZIM",
     )
 
     parser.add_argument(
@@ -153,14 +153,6 @@ def main():
 
     parser.add_argument(
         "--debug", help="Enable verbose output", action="store_true", default=False
-    )
-
-    parser.add_argument(
-        "--keep",
-        help="Don't erase build folder on start (for debug/devel)",
-        default=False,
-        action="store_true",
-        dest="keep_build_dir",
     )
 
     parser.add_argument(

--- a/scraper/src/youtube2zim/schemas.py
+++ b/scraper/src/youtube2zim/schemas.py
@@ -26,6 +26,12 @@ class Subtitle(CamelModel):
     name: str
 
 
+class Subtitles(CamelModel):
+    """Class to serialize data about a list of YouTube video subtitles."""
+
+    subtitles: list[Subtitle]
+
+
 class Video(CamelModel):
     """Class to serialize data about a YouTube video."""
 

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -10,7 +10,6 @@
 import concurrent.futures
 import datetime
 import functools
-import os
 import re
 import shutil
 import subprocess
@@ -277,9 +276,6 @@ class Youtube2Zim:
         # check that we can create a ZIM file in the output directory
         validate_zimfile_creatable(self.output_dir, self.fname)
 
-        # create output directory if it does not exist
-        os.makedirs(self.output_dir, exist_ok=True)
-
         # check that build_dir is correct
         if not self.build_dir.exists() or not self.build_dir.is_dir():
             raise OSError(f"Incorrect build_dir: {self.build_dir}")
@@ -363,6 +359,14 @@ class Youtube2Zim:
         self.zim_file.start()
 
         try:
+            logger.debug(f"Preparing zimfile at {self.zim_file.filename}")
+
+            logger.info("add main channel branding to ZIM")
+            self.add_main_channel_branding_to_zim()
+
+            logger.debug(f"add zimui files from {self.zimui_dist}")
+            self.add_zimui()
+
             # download videos (and recompress)
             logger.info(
                 "downloading all videos, subtitles and thumbnails "
@@ -390,13 +394,6 @@ class Youtube2Zim:
 
             logger.info("download all author's profile pictures")
             self.download_authors_branding()
-
-            logger.info("add main channel branding to ZIM")
-            self.add_main_channel_branding_to_zim()
-
-            logger.debug(f"Preparing zimfile at {self.zim_file.filename}")
-            logger.debug(f"Recursively adding files from {self.build_dir}")
-            self.add_zimui()
 
             logger.info("creating JSON files")
             self.make_json_files(succeeded)

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -33,7 +33,7 @@ from zimscraperlib.image.transformation import resize_image
 from zimscraperlib.inputs import compute_descriptions
 from zimscraperlib.video.presets import VideoMp4Low, VideoWebmLow
 from zimscraperlib.zim import Creator
-from zimscraperlib.zim.filesystem import FileItem, validate_zimfile_creatable
+from zimscraperlib.zim.filesystem import validate_zimfile_creatable
 from zimscraperlib.zim.metadata import (
     validate_description,
     validate_longdescription,
@@ -400,9 +400,6 @@ class Youtube2Zim:
 
             logger.info("creating JSON files")
             self.make_json_files(succeeded)
-
-            logger.info("Adding files to ZIM")
-            self.add_files_to_zim(self.build_dir, self.zim_file)
         except KeyboardInterrupt:
             self.zim_file.can_finish = False
             logger.error("KeyboardInterrupt, exiting.")
@@ -1193,13 +1190,6 @@ class Youtube2Zim:
 
         # clean videos left out in videos directory
         remove_unused_videos(videos)
-
-    def add_files_to_zim(self, dir_path: Path, zim_file: Creator):
-        """recursively add a path to a zim file"""
-        for file_path in filter(
-            lambda file_path: file_path.is_file(), dir_path.rglob("*")
-        ):
-            zim_file.add_item(FileItem(dir_path, file_path))
 
     def add_file_to_zim(
         self,

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -1197,7 +1197,12 @@ class Youtube2Zim:
         fpath: Path,
         callback: Callable | tuple[Callable, Any] | None = None,
     ):
-        """add a file to a zim file"""
+        """add a file to a ZIM file"""
+
+        if not fpath.exists():
+            logger.error(f"File {fpath} does not exist")
+            return
+        logger.debug(f"Adding {path} to ZIM")
         self.zim_file.add_item_for(
             path,
             fpath=fpath,

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -98,7 +98,6 @@ class Youtube2Zim:
         fname,
         debug,
         tmp_dir,
-        keep_build_dir,
         max_concurrency,
         language,
         tags,
@@ -172,7 +171,6 @@ class Youtube2Zim:
 
         # debug/devel options
         self.debug = debug
-        self.keep_build_dir = keep_build_dir
         self.max_concurrency = max_concurrency
 
         # update youtube credentials store
@@ -409,9 +407,8 @@ class Youtube2Zim:
             logger.info("Finishing ZIM file…")
             self.zim_file.finish()
 
-        if not self.keep_build_dir:
-            logger.info("removing temp folder")
-            shutil.rmtree(self.build_dir, ignore_errors=True)
+        logger.info("removing temp folder")
+        shutil.rmtree(self.build_dir, ignore_errors=True)
 
         logger.info("all done!")
 

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -386,6 +386,9 @@ class Youtube2Zim:
             logger.info("download all author's profile pictures")
             self.download_authors_branding()
 
+            logger.info("add main channel branding to ZIM")
+            self.add_main_channel_branding_to_zim()
+
             logger.debug(f"Preparing zimfile at {self.zim_file.filename}")
             logger.debug(f"Recursively adding files from {self.build_dir}")
             self.add_zimui()
@@ -846,6 +849,23 @@ class Youtube2Zim:
         )
         for channel_id in uniq_channel_ids:
             save_channel_branding(self.channels_dir, channel_id, save_banner=False)
+            channel_profile_path = self.channels_dir / channel_id / "profile.jpg"
+            self.add_file_to_zim(
+                f"channels/{channel_id}/profile.jpg",
+                channel_profile_path,
+                callback=(delete_callback, channel_profile_path),
+            )
+
+    def add_main_channel_branding_to_zim(self):
+        """add main channel branding to zim file"""
+        branding_items = [
+            ("profile.jpg", self.profile_path),
+            ("banner.jpg", self.banner_path),
+            ("favicon.png", self.build_dir / "favicon.png"),
+        ]
+        for filename, path in branding_items:
+            if path.exists():
+                self.add_file_to_zim(filename, path, callback=(delete_callback, path))
 
     def update_metadata(self):
         # we use title, description, profile and banner of channel/user


### PR DESCRIPTION
Close #204
Close #209

Changes in this PR:
- Remove `--no-zim` CLI argument.
- Add items "on the fly" to the ZIM:
   - Videos and video thumbnails are added to ZIM immediately after they are downloaded.
   - Channel branding of main channel (profile.jpg) is added after creating the favicon using it.
   - Subtitles are added to ZIM immediately after download. Information about language codes are cached so that it can be used later on to generate JSON files for individual videos.
 - Use `validate_zimfile_creatable` from `zimscraperlib` to validate if ZIM cannot be created at given location / name.
 - Remove `add_files_to_zim` method from Youtube2Zim class, since we no longer have to copy the whole build directory into the ZIM.