### PR TITLE
Hide playlists tab in `zimui` if there is only 1 playlist

### DIFF
--- a/scraper/src/youtube2zim/schemas.py
+++ b/scraper/src/youtube2zim/schemas.py
@@ -100,6 +100,7 @@ class Channel(CamelModel):
     joined_date: str
     collection_type: str
     main_playlist: str | None = None
+    playlist_count: int
 
 
 class Config(CamelModel):

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -1177,6 +1177,7 @@ class Youtube2Zim:
                 banner_path="banner.jpg",
                 collection_type=self.collection_type,
                 main_playlist=main_playlist_slug,
+                playlist_count=len(self.playlists),
                 joined_date=channel_data["snippet"]["publishedAt"],
             ).model_dump_json(by_alias=True, indent=2),
             mimetype="application/json",

--- a/zimui/src/components/channel/ChannelHeader.vue
+++ b/zimui/src/components/channel/ChannelHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useDisplay } from 'vuetify'
 
 import AboutDialogButton from '@/components/channel/AboutDialogButton.vue'
@@ -32,6 +32,9 @@ const tabs = [
   }
 ]
 
+// Hide tabs if there is only one playlist
+const hideTabs = computed(() => main.channel?.playlistCount === 1)
+
 const tab = ref<number>(tabs[0].id)
 </script>
 
@@ -47,7 +50,7 @@ const tab = ref<number>(tabs[0].id)
       ></v-parallax>
 
       <!-- Channel Info -->
-      <v-container class="channel-info px-8" :fluid="mdAndDown">
+      <v-container class="channel-info px-8" :class="{ 'py-8': hideTabs }" :fluid="mdAndDown">
         <v-row>
           <v-col cols="12" md="8" class="d-flex flex-column flex-md-row align-center">
             <v-avatar size="75" class="channel-avatar border-thin">
@@ -76,7 +79,7 @@ const tab = ref<number>(tabs[0].id)
       </v-container>
 
       <!-- Tabs Navigation -->
-      <v-tabs v-if="tabs.length > 0" v-model="tab" align-tabs="center">
+      <v-tabs v-if="!hideTabs" v-model="tab" align-tabs="center">
         <v-tab v-for="item in tabs" :key="item.id" :to="item.to">
           {{ item.title }}
         </v-tab>

--- a/zimui/src/types/Channel.ts
+++ b/zimui/src/types/Channel.ts
@@ -9,6 +9,7 @@ export interface Channel {
   joinedDate: string
   collectionType: string
   mainPlaylist?: string
+  playlistCount: number
 }
 
 export interface Config {


### PR DESCRIPTION
As per the suggestion in https://github.com/openzim/youtube/issues/261#issuecomment-2223121230, the `Playlist` tab in the Vue.js UI can be hidden if there is only 1 playlist in the ZIM. Changes in this PR:
- Add `playlist_count` to channel.json
- Modify `ChannerHeader.vue` to hide the tabs based on the `playlist_count` value.

Screenshot (ZIM with only 1 playlist):
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/2da97cc6-77c3-4b2c-b673-5d622ebba63a">
