### PR TITLE
Fix channel title truncation for smaller screens in zimui

### DIFF
--- a/zimui/src/components/channel/AboutDialogButton.vue
+++ b/zimui/src/components/channel/AboutDialogButton.vue
@@ -15,6 +15,10 @@ const props = defineProps({
   joinedDate: {
     type: String,
     required: true
+  },
+  small: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -27,7 +31,7 @@ const formattedDate = computed(() => {
 </script>
 
 <template>
-  <v-btn class="border-thin" flat @click="dialog = true">
+  <v-btn class="border-thin" :size="small ? 'small' : 'default'" flat @click="dialog = true">
     <v-icon icon="mdi-information-outline" start></v-icon>
     About Channel
   </v-btn>

--- a/zimui/src/components/video/player/VideoChannelInfo.vue
+++ b/zimui/src/components/video/player/VideoChannelInfo.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useDisplay } from 'vuetify'
 import profilePlaceholder from '@/assets/images/profile-placeholder.jpg'
 import AboutDialogButton from '@/components/channel/AboutDialogButton.vue'
+
+const { smAndDown } = useDisplay()
 
 const props = defineProps({
   profilePath: {
@@ -25,11 +28,13 @@ const props = defineProps({
 <template>
   <v-row>
     <v-col cols="6" class="d-flex align-center py-2">
-      <router-link :to="{ name: 'home' }">
+      <router-link :to="{ name: 'home' }" class="channel-link d-flex align-center">
         <v-avatar size="50" class="border-thin">
           <v-img :src="props.profilePath" :lazy-src="profilePlaceholder" />
         </v-avatar>
-        <span class="video-channel ml-2 font-weight-medium">{{ props.channelTitle }}</span>
+        <span class="video-channel ml-2 font-weight-medium d-inline-block text-truncate">{{
+          props.channelTitle
+        }}</span>
       </router-link>
     </v-col>
     <v-col cols="6" class="d-flex justify-end align-center">
@@ -37,12 +42,17 @@ const props = defineProps({
         :title="props.channelTitle"
         :description="props.channelDescription"
         :joined-date="props.joinedDate"
+        :small="smAndDown"
       />
     </v-col>
   </v-row>
 </template>
 
 <style scoped>
+.channel-link {
+  min-width: 0;
+}
+
 .video-channel {
   color: initial;
 }


### PR DESCRIPTION
Fix #264

Fix the channel title truncation on smaller screen devices, so that the channel name doesn't break into multiple lines.

Before:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/3f0b9a49-3ea1-44ed-9b01-894f74e4f9ba">

After:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/5741a383-4fe1-4f6e-aae0-6033eb800157">