### PR TITLE
Disable preloading of subtitles in video.js

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Disable preloading of subtitles in video.js in `zimui` (#38)
 
 ## [3.0.0] - 2024-07-29
 

--- a/zimui/src/views/VideoPlayerView.vue
+++ b/zimui/src/views/VideoPlayerView.vue
@@ -106,8 +106,10 @@ const videoOptions = ref({
   controlBar: { pictureInPictureToggle: false },
   playbackRates: [0.25, 0.5, 1, 1.5, 2],
   techOrder: ['html5', 'ogvjs'],
+  html5: { preloadTextTracks: false },
   ogvjs: {
-    base: './assets/ogvjs'
+    base: './assets/ogvjs',
+    preloadTextTracks: false
   },
   poster: videoPoster,
   sources: [


### PR DESCRIPTION
Close #38

This PR disables the preloading of subtitles in video.js for `zimui`. Changes include:
- Set `preloadTextTracks` as false for both `html5` and `ogvjs` tech plugins.

Tested on `Chrome v127` and `Safari 11.1`