### PR TITLE
Cache subtitles in S3 storage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Disable preloading of subtitles in video.js in `zimui` (#38)
+- Update `download_subtitles` method to cache subtitles in S3 storage (#277)
 
 ## [3.0.0] - 2024-07-29
 


### PR DESCRIPTION
This PR modifies the `download_subtitles` method to cache subtitles in S3. The modified method now works as follows:

- Fetch requested subtitle keys using `yt-dlp` (e.g., `en`, `fr`, `de`) and store them in `requested_subtitle_keys`.
- Iterate through the `requested_subtitle_keys` and attempt to download each subtitle file from the S3 cache. If a file is - successfully downloaded from the S3 cache, remove the corresponding key from `requested_subtitle_keys`.
- For the remaining keys in `requested_subtitle_keys`, download the subtitles using `yt-dlp`.
- Upload the newly downloaded subtitles to the S3 cache.
- Save the information about the fetched subtitles in a local cache as a JSON file for future use.
- Add the downloaded subtitles to the ZIM file.

Close #277