### PR TITLE
Report scraper progress in a JSON file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Report scraper progress in a JSON file specified with `--stats-filename` (#228)
+
 ## [3.0.1] - 2024-08-13
 
 ### Fixed

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "pif==0.8.2",
   "pydantic==2.7.2",
   "pyhumps==3.8.0",
+  "schedule==1.2.2",
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 

--- a/scraper/src/youtube2zim/entrypoint.py
+++ b/scraper/src/youtube2zim/entrypoint.py
@@ -196,6 +196,12 @@ def main():
         action="store_true",
     )
 
+    parser.add_argument(
+        "--stats-filename",
+        help="Path to store the progress JSON file to.",
+        dest="stats_filename",
+    )
+
     args = parser.parse_args()
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 


### PR DESCRIPTION
Close #228

Changes:
- Add new CLI argument `--stats-filename` to specify the path to store the progress JSON file to.
- Add helper function `report_progress` to write the scraper's progress (`done` and `total`) to the specified location in the above CLI argument.
- Schedule `report_progress` to run every 10 seconds.