### PR TITLE
Fix main playlist selection to respect the order of provided playlist IDs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Report scraper progress in a JSON file specified with `--stats-filename` (#228)
+- Fix main playlist selection to respect the order of provided playlist IDs (#286)
 
 ## [3.0.1] - 2024-08-13
 

--- a/scraper/src/youtube2zim/youtube.py
+++ b/scraper/src/youtube2zim/youtube.py
@@ -345,7 +345,8 @@ def extract_playlists_details_from(collection_type, youtube_id):
         raise NotImplementedError("unsupported collection_type")
 
     return (
-        [Playlist.from_id(playlist_id) for playlist_id in list(set(playlist_ids))],
+        # dict.fromkeys maintains the order of playlist_ids while removing duplicates
+        [Playlist.from_id(playlist_id) for playlist_id in dict.fromkeys(playlist_ids)],
         main_channel_id,
         uploads_playlist_id,
     )


### PR DESCRIPTION
Close #286

Changes:
- Replace `list(set(playlist_ids))` to `dict.fromkeys(playlist_ids)` to maintain the order of the given playlist IDs.