### PR TITLE
Update zimui HTML page title dynamically with playlist/video title

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Report scraper progress in a JSON file specified with `--stats-filename` (#228)
 - Fix main playlist selection to respect the order of provided playlist IDs (#286)
+- Update `zimui` title dynamically with the selected playlist/video title (#298)
 
 ## [3.0.1] - 2024-08-13
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report scraper progress in a JSON file specified with `--stats-filename` (#228)
 - Fix main playlist selection to respect the order of provided playlist IDs (#286)
 - Update `zimui` title dynamically with the selected playlist/video title (#298)
+- Fix `PLAYLISTS` tab not being highlighted when the page is reloaded (#299)
 
 ## [3.0.1] - 2024-08-13
 

--- a/zimui/src/components/channel/ChannelHeader.vue
+++ b/zimui/src/components/channel/ChannelHeader.vue
@@ -83,7 +83,7 @@ const tab = ref<number>(tabs[0].id)
       <!-- Tabs Navigation -->
       <v-tabs v-if="!hideTabs" v-model="tab" align-tabs="center">
         <router-link v-for="item in tabs" :key="item.id" :to="item.to" class="text-black">
-          <v-tab>
+          <v-tab :to="item.to">
             {{ item.title }}
           </v-tab>
         </router-link>

--- a/zimui/src/views/HomeView.vue
+++ b/zimui/src/views/HomeView.vue
@@ -1,5 +1,18 @@
 <script setup lang="ts">
+import { watch } from 'vue'
+import { useMainStore } from '@/stores/main'
+
 import ChannelHeader from '@/components/channel/ChannelHeader.vue'
+
+const main = useMainStore()
+
+// Update the document title with the channel title
+watch(
+  () => main.channel,
+  () => {
+    if (main.channel) document.title = main.channel.title
+  }
+)
 </script>
 
 <template>

--- a/zimui/src/views/PlaylistView.vue
+++ b/zimui/src/views/PlaylistView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, type Ref, onMounted } from 'vue'
+import { ref, type Ref, onMounted, watch } from 'vue'
 import { useDisplay } from 'vuetify'
 import { useMainStore } from '@/stores/main'
 import { useRoute, useRouter } from 'vue-router'
@@ -69,6 +69,14 @@ onMounted(() => {
 })
 
 const { mdAndDown } = useDisplay()
+
+// Update the document title with the playlist title
+watch(
+  () => playlist.value,
+  () => {
+    if (playlist.value) document.title = playlist.value.title
+  }
+)
 </script>
 
 <template>

--- a/zimui/src/views/VideoPlayerView.vue
+++ b/zimui/src/views/VideoPlayerView.vue
@@ -168,6 +168,14 @@ const cycleLoopOption = () => {
   const currentIndex = loopOptions.indexOf(main.loop)
   main.setLoop(loopOptions[(currentIndex + 1) % loopOptions.length])
 }
+
+// Update the document title with the video title
+watch(
+  () => video.value,
+  () => {
+    if (video.value) document.title = video.value.title
+  }
+)
 </script>
 
 <template>


### PR DESCRIPTION
Fix #298
Fix #299

Changes:
- Update `zimui` title dynamically with the selected playlist/video title.
- Fix PLAYLISTS tab not being highlighted when the page is reloaded.