### PR TITLE
Enhance yt_dlp format and fix bug

### DIFF
--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -641,8 +641,8 @@ class Youtube2Zim:
             # "external_downloader_args": ["--max-tries=20", "--retry-wait=30"],
             "outtmpl": str(self.videos_dir.joinpath("%(id)s", "video.%(ext)s")),
             "preferredcodec": self.video_format,
-            "format": f"best[ext={vidext}]/"
-            f"bestvideo[ext={vidext}]+bestaudio[ext={audext}]/best",
+            "format": f"bestvideo*[ext={vidext}]+bestaudio[ext={audext}]/"
+            "bestvideo*+bestaudio/best",
             "y2z_videos_dir": self.videos_dir,
         }
         if self.all_subtitles:


### PR DESCRIPTION
Fix #351 

Changes:
- see https://github.com/openzim/youtube/issues/351#issuecomment-2397765106 for details
- it allows to fix bug linked to the fact that we have more often no more merged stream with both video and audio
- it enhances the chances to grab best suited stream(s) before reencoding