### PR TITLE
Raise exception if there are no videos in the playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise exception if there are no videos in the playlists (#347)
+
 ## [3.2.0] - 2024-10-11
 
 ### Deprecated

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -618,6 +618,10 @@ class Youtube2Zim:
 
             for playlist in empty_playlists:
                 self.playlists.remove(playlist)
+
+            # Raise exception if no videos found in playlists
+            if not self.playlists:
+                raise Exception("No videos found in playlists")
         self.videos_ids = [*all_videos.keys()]  # unpacking so it's subscriptable
 
     def download_video_files(self, max_concurrency):


### PR DESCRIPTION
Fix #347

Raise exception if there are no videos in the playlists instead of creating an empty ZIM file. 
Tested with this playlist: https://www.youtube.com/playlist?list=PL5glJe_RySVnGr4P1ZCW3Ou32pkz0z-yY