### PR TITLE
Use proper ZIM metadata key for `Scraper` and `Tags`

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -100,7 +100,7 @@ jobs:
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
           OPTIMIZATION_CACHE_URL: ${{ secrets.OPTIMIZATION_CACHE_URL }}
-        run: docker run -v $PWD/output:/output youtube2zim youtube2zim --api-key "$YOUTUBE_API_KEY" --optimization-cache "$OPTIMIZATION_CACHE_URL" --type channel --id "UC8elThf5TGMpQfQc_VE917Q" --name "openZIM_testing" --zim-file "openZIM_testing.zim"
+        run: docker run -v $PWD/output:/output youtube2zim youtube2zim --api-key "$YOUTUBE_API_KEY" --optimization-cache "$OPTIMIZATION_CACHE_URL" --type channel --id "UC8elThf5TGMpQfQc_VE917Q" --name "tests_en_openzim-testing" --zim-file "openZIM_testing.zim" --tags "tEsTing,x-mark:yes"
 
       - name: Run integration test suite
         run: docker run -v $PWD/scraper/tests-integration/integration.py:/src/scraper/tests-integration/integration.py -v $PWD/output:/output youtube2zim bash -c "pip install pytest; pytest -v /src/scraper/tests-integration/integration.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Filter-out non-public videos and properly cleanup unsuccessful videos (#362)
+- Use proper ZIM metadata key for `Scraper` and `Tags` (#369)
 
 ## [3.2.0] - 2024-10-11
 

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -382,8 +382,8 @@ class Youtube2Zim:
                 LongDescription=self.long_description,
                 Creator=self.creator,
                 Publisher=self.publisher,
-                tags=";".join(self.tags) if self.tags else "",
-                scraper=SCRAPER,
+                Tags=";".join(self.tags) if self.tags else "",
+                Scraper=SCRAPER,
                 Date=datetime.date.today(),
                 Illustration_48x48_at_1=illustration_data,
             )

--- a/scraper/tests-integration/integration.py
+++ b/scraper/tests-integration/integration.py
@@ -24,12 +24,14 @@ def test_zim_metadata():
 
     zim_fh = Archive(ZIM_FILE_PATH)
 
-    assert "youtube2zim " in zim_fh.get_text_metadata("scraper")
-    assert "openZIM_testing" in zim_fh.get_text_metadata("Title")
-    assert "-" in zim_fh.get_text_metadata("Description")
-    assert "en" in zim_fh.get_text_metadata("Language")
-    assert "openZIM" in zim_fh.get_text_metadata("Publisher")
-    assert "openZIM_testing" in zim_fh.get_text_metadata("Creator")
+    assert "youtube2zim " in zim_fh.get_text_metadata("Scraper")
+    assert zim_fh.get_text_metadata("Tags") == "tEsTing;x-mark:yes;_videos:yes"
+    assert zim_fh.get_text_metadata("Title") == "openZIM_testing"
+    assert zim_fh.get_text_metadata("Description") == "-"
+    assert zim_fh.get_text_metadata("Language") == "eng"
+    assert zim_fh.get_text_metadata("Name") == "tests_en_openzim-testing"
+    assert zim_fh.get_text_metadata("Publisher") == "openZIM"
+    assert zim_fh.get_text_metadata("Creator") == "Youtube Channel “openZIM_testing”"
 
     assert zim_fh.get_item("profile.jpg").mimetype == "image/jpeg"
     assert zim_fh.get_item("favicon.png").mimetype == "image/png"


### PR DESCRIPTION
Fix #369 

Changes:
- I've also enhanced a bit the integration tests for better checks (even if we can see that we already had a test about `scraper` metadata instead of `Scraper`, so it will not solve the problem we had in this issue at all)