### PR TITLE
Always reencode using our presets (even for high quality) and choose best format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Raise exception if there are no videos in the playlists (#347)
 - Drop `--type` CLI argument and guess `--id` type (#361)
+- Always reencode using our presets (even for high quality) and choose best format when downloading from Youtube (#356)
 
 ### Fixed
 

--- a/scraper/src/youtube2zim/processing.py
+++ b/scraper/src/youtube2zim/processing.py
@@ -28,11 +28,11 @@ def process_thumbnail(thumbnail_path, preset):
     return True
 
 
-def post_process_video(video_dir, video_id, preset, video_format, low_quality):
+def post_process_video(video_dir, video_id, preset, video_format):
     """apply custom post-processing to downloaded video
 
     - resize thumbnail
-    - recompress video if incorrect video_format or low_quality requested"""
+    - recompress video"""
 
     # find downloaded video from video_dir
     files = [
@@ -51,10 +51,6 @@ def post_process_video(video_dir, video_id, preset, video_format, low_quality):
             f"Picking {files[0]} out of {files}"
         )
     src_path = files[0]
-
-    # don't reencode if not requesting low-quality and received wanted format
-    if not low_quality and src_path.suffix[1:] == video_format:
-        return
 
     dst_path = src_path.with_name(f"video.{video_format}")
     logger.info(f"Reencode video to {dst_path}")


### PR DESCRIPTION
Fix #356

# Changes
- simplify choosing best format from youtube to be sure to have a format with highest resolution possible in all cases to avoid problems while re-encoding
- always reencode (even for high quality) using our presets, to simplify things (otherwise it is too much dependent on Youtube choices in terms of resolution and codecs and bitrates, hard to follow)