### PR TITLE
Check for empty playlists after filtering, and after downloading videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check for empty playlists after filtering, and after downloading videos (#375)
+
 ## [3.2.1] - 2024-11-01
 
 ### Deprecated


### PR DESCRIPTION
Fix #375

Two problems have been fixed:
- scraper was checking the playlist is not empty before filtering by date range, deleted videos, ... => some playlists finally empty were not detected
- scraper was not checking wether the playlist is empty after downloading videos (we could have a majority of videos OK, but all videos of a playlist fails then the playlist is empty