### PR TITLE
Unlisted videos must also be included inside the ZIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Corrected the short video resolution in the UI (#366)
 - Check for empty playlists after filtering, and after downloading videos (#375)
+- Unlisted videos must also be included inside the ZIM (#379)
 
 ## [3.2.1] - 2024-11-01
 

--- a/scraper/src/youtube2zim/youtube.py
+++ b/scraper/src/youtube2zim/youtube.py
@@ -332,7 +332,7 @@ def skip_deleted_videos(item):
 
 def skip_non_public_videos(item):
     """filter func to filter-out non-public videos"""
-    return item["status"]["privacyStatus"] == "public"
+    return item["status"]["privacyStatus"] in ("public", "unlisted")
 
 
 def skip_outofrange_videos(date_range, item):


### PR DESCRIPTION
Unlisted videos have to be considered for ZIM inclusion. The fact they are not listed does not means they are not viewable, see e.g. https://www.youtube.com/playlist?list=PL3rEvTTL-Jm-ZIeAfA6U726nsdYaWn4lL ; all videos are unlisted but anyone knowing the playlist will be able to find the video. Unlisted only refers to the fact that it won't come up in search results or be listed on channel home page. Since we explore by playlist ID, we should always include these videos.