### PR TITLE
Feat: support video chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for video chapters (#170)
+
 ## [3.3.0] - 2024-12-05
 
 ### Changed

--- a/scraper/src/youtube2zim/schemas.py
+++ b/scraper/src/youtube2zim/schemas.py
@@ -26,6 +26,14 @@ class Subtitle(CamelModel):
     name: str
 
 
+class Chapter(CamelModel):
+    """Class to serialize data about YouTube Video chapter"""
+
+    start_time: float | int
+    end_time: float | int
+    title: str
+
+
 class Subtitles(CamelModel):
     """Class to serialize data about a list of YouTube video subtitles."""
 
@@ -44,6 +52,8 @@ class Video(CamelModel):
     thumbnail_path: str | None = None
     subtitle_path: str | None = None
     subtitle_list: list[Subtitle]
+    chapters_path: str | None = None
+    chapter_list: list[Chapter]
     duration: str
 
 

--- a/zimui/src/assets/vjs-youtube.css
+++ b/zimui/src/assets/vjs-youtube.css
@@ -55,7 +55,6 @@
   border-radius: 8px;
 }
 
-
 .video-js.vjs-fluid,
 .video-js.vjs-16-9,
 .video-js.vjs-4-3,
@@ -88,4 +87,19 @@ video.vjs-tech {
   height: 100% !important;
   max-height: 100vh;
   object-fit: contain;
+}
+
+.custom-marker {
+  position: absolute;
+  bottom: 0;
+  width: 5px;
+  height: 100%;
+  background-color: #aaa;
+  cursor: pointer;
+}
+
+.vjs-time-tooltip {
+  transform: translateY(-80%) !important;
+  line-height: 1.5;
+  padding: 3px 6px !important;
 }

--- a/zimui/src/components/video/VideoPlayer.vue
+++ b/zimui/src/components/video/VideoPlayer.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch, nextTick, type PropType } from 'vue'
 import videojs from 'video.js'
 import type Player from 'video.js/dist/types/player'
 
 import 'video.js/dist/video-js.css'
 import '@/assets/vjs-youtube.css'
 import '@/plugins/videojs-ogvjs.js'
+import { timeToSeconds } from '@/utils/format-utils'
+import type TimeTooltip from '@/types/videojs'
 
 const props = defineProps({
   options: {
@@ -15,37 +17,150 @@ const props = defineProps({
   loop: {
     type: Boolean,
     default: false
+  },
+  chaptersList: {
+    type: Array as PropType<{ startTime: number; endTime: number; title: string }[]>,
+    default: () => []
   }
 })
 
-const videoPlayer = ref<HTMLVideoElement>()
+const videoContainer = ref<HTMLVideoElement>()
 const player = ref<Player>()
+const chapterList = ref<{ startTime: number; endTime: number; title: string }[]>([])
 
 const emit = defineEmits(['video-ended'])
 
-// Initialize video.js when the component is mounted
-onMounted(() => {
-  if (videoPlayer.value) {
-    player.value = videojs(videoPlayer.value, props.options)
-    player.value.loop(props.loop)
+const addMarkers = () => {
+  if (player.value) {
+    const progressBar = player.value
+      ?.getChild('controlBar')
+      ?.getChild('progressControl')
+      ?.getChild('seekBar')
+      ?.el()
+
+    if (!progressBar) return
+    const duration = player.value?.duration()
+    if (!duration) return
+
+    progressBar.querySelectorAll('.custom-marker').forEach((el) => el.remove())
+
+    chapterList.value.forEach((marker) => {
+      const markerEl = document.createElement('div')
+      markerEl.classList.add('custom-marker')
+      if (marker.startTime < 0 || marker.startTime > duration) return
+      markerEl.style.left = `${(marker.startTime / duration) * 100}%`
+      progressBar.appendChild(markerEl)
+    })
+  }
+}
+
+const getChapterAtTime = (timestr: string) => {
+  const inputSeconds = timeToSeconds(timestr)
+
+  for (const chapter of chapterList.value) {
+    if (chapter.startTime <= inputSeconds && chapter.endTime > inputSeconds) {
+      return chapter.title
+    }
+  }
+
+  return null
+}
+
+const initPlayer = () => {
+  if (!videoContainer.value) return
+
+  // Remove existing video element if present
+  videoContainer.value.innerHTML = ''
+
+  // Create a new video element dynamically
+  const videoElement = document.createElement('video')
+  videoElement.className = 'video-js vjs-youtube'
+  videoElement.setAttribute('playsinline', '')
+  videoElement.setAttribute('controls', props.options.controls ? 'true' : 'false')
+  videoElement.setAttribute('preload', props.options.preload)
+  videoElement.setAttribute('autoplay', props.options.autoplay ? 'true' : 'false')
+  if (props.options.poster) {
+    videoElement.setAttribute('poster', props.options.poster)
+  }
+
+  // Append sources dynamically
+  props.options.sources.forEach((source: Record<string, string>) => {
+    const sourceElement = document.createElement('source')
+    sourceElement.src = source.src
+    sourceElement.type = source.type
+    videoElement.appendChild(sourceElement)
+  })
+
+  // Append the new video element to the container
+  videoContainer.value.appendChild(videoElement)
+
+  // Initialize Video.js on the new video element
+  nextTick(() => {
+    player.value = videojs(videoElement, props.options)
+    player.value.loop(props.options.loop)
     player.value.on('ended', () => {
       emit('video-ended')
     })
+    if (props.chaptersList) {
+      chapterList.value = props.chaptersList
+    }
+
+    player.value?.on('loadedmetadata', () => {
+      addMarkers()
+      nextTick(() => {
+        updateChapterTimeTooltip()
+      })
+    })
+  })
+}
+
+const updateChapterTimeTooltip = () => {
+  if (player.value) {
+    const timeTooltip = player.value
+      ?.getChild('controlBar')
+      ?.getChild('progressControl')
+      ?.getChild('seekBar')
+      ?.getChild('mouseTimeDisplay')
+      ?.getChild('timeTooltip') as TimeTooltip
+
+    if (!timeTooltip) return
+
+    timeTooltip.update = function (seekBarRect: DOMRect, seekBarPoint: number, time: string) {
+      const chapter = getChapterAtTime(time)
+      if (chapter) {
+        this.write(`${chapter.replace(/ /g, '\u00A0')}\n${time}`)
+        return
+      }
+      this.write(`${time}`)
+    }
   }
+}
+
+// Initialize video.js when the component is mounted
+onMounted(() => {
+  initPlayer()
 })
 
 // Watch for changes in the options prop
 watch(
   () => props.options,
-  (newOptions) => {
+  () => {
     if (player.value) {
-      player.value.src(newOptions.sources)
-      if (newOptions.autoplay === true) {
-        player.value.play()
-      } else {
-        player.value.poster(newOptions.poster)
-      }
+      player.value.dispose()
+      initPlayer()
     }
+  },
+  { deep: true }
+)
+
+watch(
+  () => props.chaptersList,
+  (newList) => {
+    chapterList.value = newList
+    nextTick(() => {
+      addMarkers()
+      updateChapterTimeTooltip()
+    })
   },
   { deep: true }
 )
@@ -69,30 +184,5 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div>
-    <video
-      ref="videoPlayer"
-      class="video-js vjs-youtube"
-      :controls="props.options.controls"
-      :preload="props.options.preload"
-      :autoplay="props.options.autoplay"
-      :poster="props.options.poster"
-      playsinline
-    >
-      <source
-        v-for="(source, idx) in props.options.sources"
-        :key="idx"
-        :src="source.src"
-        :type="source.type"
-      />
-      <track
-        v-for="(track, idx) in props.options.tracks"
-        :key="idx"
-        :kind="track.kind"
-        :src="track.src"
-        :srclang="track.code"
-        :label="track.label"
-      />
-    </video>
-  </div>
+  <div ref="videoContainer"></div>
 </template>

--- a/zimui/src/types/Videos.ts
+++ b/zimui/src/types/Videos.ts
@@ -10,6 +10,8 @@ export interface Video {
   thumbnailPath?: string
   subtitlePath?: string
   subtitleList: Subtitle[]
+  chaptersPath?: string
+  chapterList: Chapter[]
   duration: string
 }
 
@@ -24,4 +26,10 @@ export interface VideoPreview {
 export default interface Subtitle {
   code: string
   name: string
+}
+
+export interface Chapter {
+  startTime: number
+  endTime: number
+  title: string
 }

--- a/zimui/src/types/videojs.ts
+++ b/zimui/src/types/videojs.ts
@@ -1,0 +1,6 @@
+import Component from 'video.js/dist/types/component'
+
+export default interface TimeTooltip extends Component {
+  update: (seekBarRect: DOMRect, seekBarPoint: number, time: string) => void
+  write: (text: string) => void
+}

--- a/zimui/src/utils/format-utils.ts
+++ b/zimui/src/utils/format-utils.ts
@@ -36,3 +36,18 @@ export const truncateText = (text: string, maxLength: number): string => {
   }
   return text
 }
+
+export const timeToSeconds = (timestr: string) => {
+  const parts = timestr.split(':').map(Number)
+  let seconds = 0
+
+  if (parts.length === 3) {
+    seconds = parts[0] * 3600 + parts[1] * 60 + parts[2]
+  } else if (parts.length === 2) {
+    seconds = parts[0] * 60 + parts[1]
+  } else if (parts.length === 1) {
+    seconds = parts[0]
+  }
+
+  return seconds
+}

--- a/zimui/src/views/VideoPlayerView.vue
+++ b/zimui/src/views/VideoPlayerView.vue
@@ -85,6 +85,10 @@ const videoPoster = computed<string>(() => {
   return video.value?.thumbnailPath || ''
 })
 
+const chapterList = computed(() => {
+  return video.value?.chapterList ?? []
+})
+
 const subtitles = computed(() => {
   return video.value?.subtitleList.map((subtitle) => {
     return {
@@ -94,6 +98,25 @@ const subtitles = computed(() => {
       label: subtitle.name
     }
   })
+})
+
+const chapters = computed(() => {
+  if (!video.value?.chaptersPath) {
+    return []
+  }
+  return [
+    {
+      kind: 'chapters',
+      src: `${video.value?.chaptersPath}/chapters.vtt`,
+      srclang: 'en',
+      label: 'Chapters',
+      default: true
+    }
+  ]
+})
+
+const tracks = computed(() => {
+  return [...subtitles.value, ...chapters.value]
 })
 
 const videoOptions = ref({
@@ -118,7 +141,7 @@ const videoOptions = ref({
       type: videoFormat
     }
   ],
-  tracks: subtitles
+  tracks: tracks
 })
 
 const currentVideoIndex = computed(() => {
@@ -187,6 +210,7 @@ watch(
         <video-player
           :options="videoOptions"
           :loop="main.loop === LoopOptions.loopVideo"
+          :chapters-list="chapterList"
           @video-ended="onVideoEnded"
         />
         <!-- Playlist panel for mobile devices -->


### PR DESCRIPTION
Fixes #170 
## Workflow
### scrapper
- `yt-dlp` writes a metadata file called `video.info.json` when downloading a video (without an extra yt-dlp call).
- Extract chapters from that metadata file.
- Create a `WEBVTT` file using the chapters.
### zimui
- Check for `chaptersPath` in `video.json`.
- If found, add a new track called chapter with the `WEBVTT` file.

## Chapter in player
![Screenshot from 2025-03-12 07-45-37](https://github.com/user-attachments/assets/8568e506-4e66-410b-80a0-b7b132c37883)
