### PR TITLE
Add skip controls & keyboard/touch shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for video chapters (#170)
 - Activate links, emails of video description (#390)
+- Add skip forward/backward functionality and keyboard & touch controls (#397)
 
 ## [3.3.0] - 2024-12-05
 

--- a/zimui/src/assets/vjs-youtube.css
+++ b/zimui/src/assets/vjs-youtube.css
@@ -1,5 +1,6 @@
 .vjs-youtube,
 .vjs-youtube video {
+  font-family: 'Roboto', sans-serif;
   border-radius: 8px;
   width: 100%;
   height: auto;
@@ -102,4 +103,171 @@ video.vjs-tech {
   transform: translateY(-80%) !important;
   line-height: 1.5;
   padding: 3px 6px !important;
+}
+
+.custom-video-indicator {
+  background: #000000b7;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  opacity: 0;
+}
+
+.custom-video-indicator.skip-indicator {
+  aspect-ratio: 1/1;
+  color: rgba(90, 88, 88, 0.048);
+  padding: 10px;
+  border-radius: 50%;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: small;
+  transition: opacity 0.5s color 0.5s;
+}
+
+.custom-video-indicator.skip-indicator.forward {
+  right: 20%;
+}
+
+.custom-video-indicator.skip-indicator.backward {
+  left: 20%;
+}
+
+.custom-video-indicator.skip-indicator.show {
+  opacity: 1;
+  color: white !important;
+}
+
+.custom-video-indicator.volume-indicator {
+  flex-direction: column;
+  row-gap: 25px;
+  padding: 25px 20px 15px;
+  border-radius: 5%;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: xx-large;
+  transition: opacity 0.5s color 0.5s;
+}
+
+.custom-video-indicator.volume-indicator .text {
+  font-size: small;
+  color: gray;
+}
+
+.custom-video-indicator.volume-indicator.show {
+  opacity: 1;
+  color: white !important;
+}
+
+.custom-video-indicator.chapter-indicator {
+  flex-direction: column;
+  row-gap: 20px;
+  padding: 15px;
+  border-radius: 5%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: medium;
+  transition: opacity 0.5s color 0.5s;
+}
+
+.custom-video-indicator.chapter-indicator.show {
+  opacity: 1;
+}
+
+.custom-video-indicator.playback-rate-indicator {
+  flex-direction: column;
+  row-gap: 25px;
+  padding: 20px;
+  border-radius: 5%;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: xx-large;
+  transition: opacity 0.5s color 0.5s;
+}
+
+.custom-video-indicator.playback-rate-indicator.show {
+  opacity: 1;
+}
+
+.shortCutsPopupBtn {
+  cursor: pointer;
+  position: absolute;
+  height: 35px;
+  width: 35px;
+  border-radius: 50%;
+  top: 10px;
+  right: 10px;
+  font-size: x-large;
+  background: #000000a2;
+  padding: 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+}
+
+.shortCutsPopupBtn.show {
+  opacity: 1;
+}
+
+@media (max-width: 480px) {
+  .shortCutsPopupBtn {
+    display: none !important;
+  }
+}
+
+.popup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.884);
+  color: white;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  font-size: larger;
+}
+
+.popup-overlay.show {
+  display: flex;
+}
+
+.popup-overlay .table-wraper {
+  background: white;
+  padding: 1em;
+  border-radius: 8px;
+  min-width: 300px;
+  max-width: 90%;
+  min-height: 300px;
+  max-height: 90%;
+  color: black;
+  overflow-y: auto;
+}
+
+.popup-overlay table td:first-child,
+.popup-overlay table th:first-child {
+  padding-right: 10em;
+}
+
+.popup-overlay .table-wraper table {
+  border-collapse: separate;
+  border-spacing: 0 1em;
+}
+
+.popup-overlay table th,
+.popup-overlay table td {
+  padding: 1em;
+  border-bottom: 1px solid rgba(12, 12, 12, 0.2);
+  text-align: left;
+}
+
+.popup-overlay table th {
+  font-weight: bold;
+  border-bottom: 2px solid rgba(3, 3, 3, 0.4);
 }

--- a/zimui/src/components/video/VideoPlayer.vue
+++ b/zimui/src/components/video/VideoPlayer.vue
@@ -27,8 +27,10 @@ const props = defineProps({
 const videoContainer = ref<HTMLVideoElement>()
 const player = ref<Player>()
 const chapterList = ref<{ startTime: number; endTime: number; title: string }[]>([])
+const isControlBarVisible = ref(false)
+const isShortcutsPopupVisible = ref(false)
 
-const emit = defineEmits(['video-ended'])
+const emit = defineEmits(['video-ended', 'next-video', 'prev-video'])
 
 const addMarkers = () => {
   if (player.value) {
@@ -64,6 +66,470 @@ const getChapterAtTime = (timestr: string) => {
   }
 
   return null
+}
+
+const updateChapterTimeTooltip = () => {
+  if (player.value) {
+    const timeTooltip = player.value
+      ?.getChild('controlBar')
+      ?.getChild('progressControl')
+      ?.getChild('seekBar')
+      ?.getChild('mouseTimeDisplay')
+      ?.getChild('timeTooltip') as TimeTooltip
+
+    if (!timeTooltip) return
+
+    timeTooltip.update = function (seekBarRect: DOMRect, seekBarPoint: number, time: string) {
+      const chapter = getChapterAtTime(time)
+      if (chapter) {
+        this.write(`${chapter.replace(/ /g, '\u00A0')}\n${time}`)
+        return
+      }
+      this.write(`${time}`)
+    }
+  }
+}
+
+const appendShortCutsPopupBtn = () => {
+  if (!player.value) return
+  const videoElement = player.value.el()
+
+  if (!videoElement) return
+
+  const btn = document.createElement('div')
+  btn.classList.add('shortCutsPopupBtn')
+
+  btn.innerHTML = '<i class="mdi mdi-keyboard"></i>'
+
+  btn.onclick = () => {
+    isShortcutsPopupVisible.value = true
+  }
+
+  videoElement.append(btn)
+}
+
+const appendShortCutsPopup = () => {
+  if (!player.value) return
+  const videoElement = player.value.el()
+
+  if (!videoElement) return
+
+  const popup = document.createElement('div')
+  popup.classList.add('popup-overlay')
+
+  popup.innerHTML = `
+  <div class="table-wraper">
+    <table>
+      <thead>
+        <tr>
+          <th>Key(s)</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Shift + n</td><td>Next video</td></tr>
+        <tr><td>Shift + p</td><td>Previous video</td></tr>
+        <tr><td>Arrow Left</td><td>Skip -5s</td></tr>
+        <tr><td>shift + Arrow Left</td><td>Go to previous chapter</td></tr>
+        <tr><td>Arrow Right</td><td>Skip +5s</td></tr>
+        <tr><td>shift + Arrow Right</td><td>Go to next chapter</td></tr>
+        <tr><td>Arrow Up</td><td>Increase volume</td></tr>
+        <tr><td>Arrow Down</td><td>Decrease volume</td></tr>
+        <tr><td>Space</td><td>Play/Pause</td></tr>
+        <tr><td>f</td><td>Toggle fullscreen</td></tr>
+        <tr><td>m</td><td>Toggle mute</td></tr>
+        <tr><td>j</td><td>Skip -10s</td></tr>
+        <tr><td>k</td><td>Play/Pause</td></tr>
+        <tr><td>l</td><td>Skip +10s</td></tr>
+        <tr><td>></td><td>Increase playback speed</td></tr>
+        <tr><td><</td><td>Decrease playback speed</td></tr>
+        <tr><td>Shift + ?</td><td>Show shortcuts</td></tr>
+      </tbody>
+    </table>
+  </div>
+  `
+  popup.onclick = () => {
+    isShortcutsPopupVisible.value = false
+  }
+  popup.querySelector('.table-wraper')?.addEventListener('click', (e) => {
+    e.stopPropagation()
+  })
+
+  videoElement.append(popup)
+}
+
+const appendSkipIndicator = () => {
+  if (!player.value) return
+  const videoElement = player.value.el()
+
+  if (!videoElement) return
+
+  const forwardSkipEl = document.createElement('div')
+  const backwardSkipEl = document.createElement('div')
+
+  forwardSkipEl.classList.add('custom-video-indicator', 'skip-indicator', 'forward')
+  forwardSkipEl.innerHTML = '+5 seconds'
+  backwardSkipEl.classList.add('custom-video-indicator', 'skip-indicator', 'backward')
+  backwardSkipEl.innerHTML = '-5 seconds'
+
+  videoElement.append(forwardSkipEl)
+  videoElement.append(backwardSkipEl)
+}
+
+const appendVolumeIndicator = () => {
+  if (!player.value) return
+  const videoElement = player.value.el()
+
+  if (!videoElement) return
+
+  const volumeEl = document.createElement('div')
+
+  volumeEl.classList.add('custom-video-indicator', 'volume-indicator')
+  volumeEl.innerHTML = '50%'
+
+  videoElement.append(volumeEl)
+}
+
+const appendChapterIndicator = () => {
+  if (!player.value) return
+  const videoElement = player.value.el()
+
+  if (!videoElement) return
+
+  const chapterEl = document.createElement('div')
+
+  chapterEl.classList.add('custom-video-indicator', 'chapter-indicator')
+  chapterEl.innerHTML = '<span>chapter</span>'
+
+  videoElement.append(chapterEl)
+}
+
+const appendPlaybackRateIndicator = () => {
+  if (!player.value) return
+  const videoElement = player.value.el()
+
+  if (!videoElement) return
+
+  const chapterEl = document.createElement('div')
+
+  chapterEl.classList.add('custom-video-indicator', 'playback-rate-indicator')
+  chapterEl.innerHTML = '<span>1x</span>'
+
+  videoElement.append(chapterEl)
+}
+
+const displayChapterIndicator = (chapterTitle: string) => {
+  if (!player.value) return
+  const videoElement = player.value?.el()
+
+  const targetElement = videoElement?.querySelector('.custom-video-indicator.chapter-indicator')
+  if (!targetElement) return
+
+  targetElement.innerHTML = `<span>${chapterTitle}</span>`
+
+  targetElement?.classList.add('show')
+  setTimeout(() => {
+    targetElement?.classList.remove('show')
+  }, 0.5 * 1000)
+}
+
+const displayPlaybackRateIndicator = (rate: number) => {
+  if (!player.value) return
+  const videoElement = player.value?.el()
+
+  const targetElement = videoElement?.querySelector(
+    '.custom-video-indicator.playback-rate-indicator'
+  )
+  if (!targetElement) return
+
+  targetElement.innerHTML = `<span>${rate}x</span>`
+
+  targetElement?.classList.add('show')
+  setTimeout(() => {
+    targetElement?.classList.remove('show')
+  }, 0.5 * 1000)
+}
+
+const displayVolumeIndicator = (volume?: number) => {
+  if (!player.value) return
+  const videoElement = player.value?.el()
+
+  const targetElement = videoElement?.querySelector('.custom-video-indicator.volume-indicator')
+  if (!targetElement) return
+
+  const newVolume = player.value.volume()
+  if (newVolume === undefined) return
+  let volumePercent = Math.round(newVolume * 100)
+  if (volume) {
+    volumePercent = Math.floor(volume)
+  }
+
+  targetElement.innerHTML = `<span>${volumePercent}%</span><span class="text">volume</span>`
+
+  targetElement?.classList.add('show')
+  setTimeout(() => {
+    targetElement?.classList.remove('show')
+  }, 0.5 * 1000)
+}
+
+const displaySkipIndicator = (skipTime: number) => {
+  if (!player.value) return
+  const videoElement = player.value?.el()
+
+  let targetElement: HTMLElement | null = null
+  let timeWithdirection: string = `${skipTime}`
+
+  if (skipTime > 0) {
+    targetElement = videoElement?.querySelector('.custom-video-indicator.skip-indicator.forward')
+    timeWithdirection = `+${skipTime}`
+  } else if (skipTime < 0) {
+    targetElement = videoElement?.querySelector('.custom-video-indicator.skip-indicator.backward')
+  }
+
+  if (!targetElement) return
+
+  targetElement.innerHTML = `${timeWithdirection} seconds`
+  targetElement?.classList.add('show')
+  setTimeout(() => {
+    targetElement?.classList.remove('show')
+  }, 0.5 * 1000)
+}
+
+const goToNextChapter = () => {
+  if (!player.value) return
+
+  const currentTime = player.value.currentTime()
+  if (currentTime === undefined) return
+
+  for (const chapter of chapterList.value) {
+    if (chapter.startTime > currentTime) {
+      player.value.currentTime(chapter.startTime)
+      displayChapterIndicator(chapter.title)
+      return
+    }
+  }
+}
+
+const goToPrevChapter = () => {
+  if (!player.value) return
+
+  const currentTime = player.value.currentTime()
+  if (currentTime === undefined) return
+
+  let prevChapter
+  for (const chapter of chapterList.value) {
+    if (chapter.startTime > currentTime) {
+      break
+    }
+    if (chapter.endTime <= currentTime) {
+      prevChapter = chapter
+    }
+  }
+
+  if (!prevChapter) return
+  player.value.currentTime(prevChapter.startTime)
+  displayChapterIndicator(prevChapter.title)
+}
+
+const changePlaybackRate = (direction: number) => {
+  if (!player.value) return
+  const currentRate = player.value.playbackRate()
+  if (!currentRate) return
+
+  if (direction < 0) {
+    if (currentRate <= 0.25) {
+      displayPlaybackRateIndicator(0.25)
+      return
+    }
+
+    const willChange = currentRate === 0.5 ? 0.25 : 0.5
+
+    player.value.playbackRate(currentRate - willChange)
+    displayPlaybackRateIndicator(currentRate - willChange)
+  } else if (direction > 0) {
+    if (currentRate >= 2) {
+      displayPlaybackRateIndicator(2)
+      return
+    }
+
+    const willChange = currentRate === 0.25 ? 0.25 : 0.5
+
+    player.value.playbackRate(currentRate + willChange)
+    displayPlaybackRateIndicator(currentRate + willChange)
+  }
+}
+
+const togglePause = () => {
+  if (player.value) {
+    player.value.paused() ? player.value.play() : player.value.pause()
+  }
+}
+
+const toggleFullScreen = () => {
+  if (player.value) {
+    player.value.isFullscreen() ? player.value.exitFullscreen() : player.value.requestFullscreen()
+  }
+}
+
+const toggleMute = () => {
+  if (!player.value) return
+  const volume = player.value.volume()
+
+  if (volume != undefined && volume <= 0) {
+    const newVolume = Number((0.1).toFixed(2))
+    player.value.volume(newVolume)
+    return
+  }
+
+  player.value.muted(!player.value.muted())
+}
+
+const changeVolume = (direction: number) => {
+  if (!player.value) return
+  let newVolume = player.value.volume()
+  if (newVolume === undefined) {
+    newVolume = 0
+  }
+  if (direction < 0) {
+    if (player.value.muted()) return
+    if (!(newVolume <= 0)) {
+      newVolume = Number((newVolume - 0.1).toFixed(2))
+    }
+  } else if (direction > 0) {
+    if (!(newVolume >= 1)) {
+      newVolume = Number((newVolume + 0.1).toFixed(2))
+    }
+    if (player.value.muted()) {
+      player.value.muted(false)
+      newVolume = Number((0.1).toFixed(2))
+    }
+  }
+  player.value.volume(newVolume)
+  displayVolumeIndicator()
+}
+
+const skip = (value: number) => {
+  if (!player.value) return
+  const currentTime = player.value.currentTime()
+
+  let skipTime
+  if (value < 0) {
+    skipTime = currentTime !== undefined ? currentTime + value : null
+
+    if (!skipTime || skipTime <= 0) {
+      player.value.currentTime(0)
+      displaySkipIndicator(value)
+      return
+    }
+
+    displaySkipIndicator(value)
+  } else if (value > 0) {
+    const duration = player.value.duration()
+    skipTime = currentTime !== undefined ? currentTime + value : null
+
+    if (!skipTime || !duration) return
+    if (duration < skipTime) {
+      player.value.currentTime(duration)
+      displaySkipIndicator(value)
+      return
+    }
+  }
+
+  if (!skipTime) return
+  displaySkipIndicator(value)
+  player.value.currentTime(skipTime)
+}
+
+let tappedOnVideoElement: ReturnType<typeof setTimeout> | null = null
+const handleTouch = (e: TouchEvent) => {
+  if (!player.value) return
+
+  if (!tappedOnVideoElement) {
+    tappedOnVideoElement = setTimeout(() => {
+      tappedOnVideoElement = null
+      player.value?.hasStarted_ || player.value?.play()
+    }, 300)
+  } else {
+    clearTimeout(tappedOnVideoElement)
+    tappedOnVideoElement = null
+
+    const videoElement = player.value.el()
+    if (!videoElement) return
+
+    const touch = e.touches[0]
+    const clickX = touch.clientX - videoElement.getBoundingClientRect().left
+    const middle = videoElement.clientWidth / 2
+
+    if (clickX < middle) {
+      skip(-10)
+    } else {
+      skip(10)
+    }
+  }
+}
+
+const updateControlBarState = () => {
+  if (player.value) {
+    isControlBarVisible.value =
+      player.value?.el()?.classList.contains('vjs-user-active') || player.value?.paused()
+        ? true
+        : false
+    const videoElement = player.value.el()
+
+    const targetElement = videoElement?.querySelector('.shortCutsPopupBtn')
+    if (!targetElement) return
+
+    if (isControlBarVisible.value) {
+      targetElement?.classList.add('show')
+    } else if (!isControlBarVisible.value) {
+      targetElement?.classList.remove('show')
+    }
+  }
+}
+
+const keyActions: Record<string, (e: KeyboardEvent) => void> = {
+  '?': (e: KeyboardEvent) => {
+    if (e.shiftKey) {
+      isShortcutsPopupVisible.value
+        ? (isShortcutsPopupVisible.value = false)
+        : (isShortcutsPopupVisible.value = true)
+    }
+  },
+
+  n: (e: KeyboardEvent) => e.shiftKey && emit('next-video'),
+  N: (e: KeyboardEvent) => e.shiftKey && emit('next-video'),
+  p: (e: KeyboardEvent) => e.shiftKey && emit('prev-video'),
+  P: (e: KeyboardEvent) => e.shiftKey && emit('prev-video'),
+
+  ArrowLeft: (e: KeyboardEvent) => (e.shiftKey ? goToPrevChapter() : skip(-5)),
+  ArrowRight: (e: KeyboardEvent) => (e.shiftKey ? goToNextChapter() : skip(5)),
+  j: () => skip(-10),
+  J: () => skip(-10),
+  l: () => skip(10),
+  L: () => skip(10),
+
+  ArrowUp: () => changeVolume(+1),
+  ArrowDown: () => changeVolume(-1),
+
+  ' ': () => togglePause(),
+  k: () => togglePause(),
+  K: () => togglePause(),
+
+  f: () => toggleFullScreen(),
+  F: () => toggleFullScreen(),
+
+  m: () => toggleMute(),
+  M: () => toggleMute(),
+
+  '>': () => changePlaybackRate(1),
+  '<': () => changePlaybackRate(-1)
+}
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (keyActions[e.key]) {
+    e.preventDefault()
+    keyActions[e.key](e)
+  }
 }
 
 const initPlayer = () => {
@@ -104,9 +570,28 @@ const initPlayer = () => {
     if (props.chaptersList) {
       chapterList.value = props.chaptersList
     }
+    player.value.on('useractive', updateControlBarState)
+    player.value.on('userinactive', updateControlBarState)
+
+    player.value.on('pause', updateControlBarState)
+    player.value.on('play', updateControlBarState)
 
     player.value?.on('loadedmetadata', () => {
       addMarkers()
+      appendShortCutsPopupBtn()
+      appendShortCutsPopup()
+      appendSkipIndicator()
+      appendVolumeIndicator()
+      appendChapterIndicator()
+      appendPlaybackRateIndicator()
+      if (player.value) {
+        const playerEl = player.value.el() as HTMLElement
+        playerEl.addEventListener('touchstart', handleTouch, { passive: false })
+        playerEl.addEventListener('click', () => {
+          if (!player.value) return
+          player.value.hasStarted_ || player.value.play()
+        })
+      }
       nextTick(() => {
         updateChapterTimeTooltip()
       })
@@ -114,31 +599,10 @@ const initPlayer = () => {
   })
 }
 
-const updateChapterTimeTooltip = () => {
-  if (player.value) {
-    const timeTooltip = player.value
-      ?.getChild('controlBar')
-      ?.getChild('progressControl')
-      ?.getChild('seekBar')
-      ?.getChild('mouseTimeDisplay')
-      ?.getChild('timeTooltip') as TimeTooltip
-
-    if (!timeTooltip) return
-
-    timeTooltip.update = function (seekBarRect: DOMRect, seekBarPoint: number, time: string) {
-      const chapter = getChapterAtTime(time)
-      if (chapter) {
-        this.write(`${chapter.replace(/ /g, '\u00A0')}\n${time}`)
-        return
-      }
-      this.write(`${time}`)
-    }
-  }
-}
-
 // Initialize video.js when the component is mounted
 onMounted(() => {
   initPlayer()
+  document.addEventListener('keydown', handleKeydown)
 })
 
 // Watch for changes in the options prop
@@ -165,6 +629,23 @@ watch(
   { deep: true }
 )
 
+watch(
+  () => isShortcutsPopupVisible.value,
+  () => {
+    if (player.value) {
+      const videoElement = player.value.el()
+
+      const targetElement = videoElement?.querySelector('.popup-overlay')
+      if (!targetElement) return
+
+      if (isShortcutsPopupVisible.value) {
+        targetElement?.classList.add('show')
+      } else if (!isShortcutsPopupVisible.value) {
+        targetElement?.classList.remove('show')
+      }
+    }
+  }
+)
 // Watch for changes in the loop prop
 watch(
   () => props.loop,
@@ -180,6 +661,7 @@ onBeforeUnmount(() => {
   if (player.value) {
     player.value.dispose()
   }
+  document.removeEventListener('keydown', handleKeydown)
 })
 </script>
 

--- a/zimui/src/views/VideoPlayerView.vue
+++ b/zimui/src/views/VideoPlayerView.vue
@@ -180,6 +180,30 @@ const onVideoEnded = () => {
   }
 }
 
+const goToNextVideo = () => {
+  if (!playlist.value) return
+  if (currentVideoIndex.value === playlist.value.videos.length - 1) return
+  video_slug.value =
+    playlist.value.videos[(currentVideoIndex.value + 1) % playlist.value.videos.length].slug
+  router.push({
+    name: 'watch-video',
+    params: { slug: video_slug.value },
+    query: { list: playlist_slug.value }
+  })
+}
+
+const goToPrevVideo = () => {
+  if (!playlist.value) return
+  if (currentVideoIndex.value === 0) return
+  video_slug.value =
+    playlist.value.videos[(currentVideoIndex.value - 1) % playlist.value.videos.length].slug
+  router.push({
+    name: 'watch-video',
+    params: { slug: video_slug.value },
+    query: { list: playlist_slug.value }
+  })
+}
+
 const { smAndDown, mdAndDown } = useDisplay()
 
 const loopOptions: LoopOptions[] = [
@@ -212,6 +236,8 @@ watch(
           :loop="main.loop === LoopOptions.loopVideo"
           :chapters-list="chapterList"
           @video-ended="onVideoEnded"
+          @next-video="goToNextVideo"
+          @prev-video="goToPrevVideo"
         />
         <!-- Playlist panel for mobile devices -->
         <div v-if="smAndDown && playlist" class="mt-5">


### PR DESCRIPTION
Fix #397 

This PR enhances the video player by adding skip **forward/backward** functionality and **keyboard & touch controls** like youtube for a better user experience.

### Touch Support:

1. `Double-tap left/right` to skip 10s

### Keyboard Shortcuts:

| **Key(s)**       | **Action**                    |
|------------------|--------------------------------|
| `Shift + N`/ `Shift + n`      | Next video                     |
| `Shift + P` / `Shift + p`     | Previous video                 |
| `Arrow Left`     | Skip **-5s**                   |
| `Shift + Arrow Left` | Go to **previous chapter**  |
| `Arrow Right`    | Skip **+5s**                   |
| `Shift + Arrow Right` | Go to **next chapter**     |
| `Arrow Up`       | Increase volume                |
| `Arrow Down`     | Decrease volume                |
| `Space`          | Play/Pause                     |
| `F` / `f` | Toggle fullscreen             |
| `M` / `m` | Toggle mute                   |
| `J` / `j` | Skip **-10s**                 |
| `K` / `k` | Play/Pause                    |
| `L` / `l` | Skip **+10s**                 |
| `>`      | Increase playback speed        |
| `<`      | Decrease playback speed        |