### PR TITLE
Add theater mode to video player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for video chapters (#170)
 - Activate links, emails of video description (#390)
 - Add skip forward/backward functionality and keyboard & touch controls (#397)
+- Add theater mode to video player (#399)
 
 ## [3.3.0] - 2024-12-05
 

--- a/zimui/src/assets/vjs-youtube.css
+++ b/zimui/src/assets/vjs-youtube.css
@@ -271,3 +271,23 @@ video.vjs-tech {
   font-weight: bold;
   border-bottom: 2px solid rgba(3, 3, 3, 0.4);
 }
+
+.watch-default-mode, 
+.watch-theater-mode {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  grid-template-rows: repeat(2,auto);
+}
+
+.watch-default-mode-smAndDown {
+  grid-template-columns: 1fr;
+}
+
+.watch-default-mode .playlist-panel{
+  grid-column: 2;
+  grid-row: 1 / 3;
+}
+
+.watch-theater-mode .video-player{
+  grid-column: 1 / 3;
+}

--- a/zimui/src/stores/main.ts
+++ b/zimui/src/stores/main.ts
@@ -11,6 +11,7 @@ export type RootState = {
   errorDetails: string
   loop: LoopOptions
   shuffle: boolean
+  theaterMode: boolean
 }
 
 export const useMainStore = defineStore('main', {
@@ -21,7 +22,8 @@ export const useMainStore = defineStore('main', {
       errorMessage: '',
       errorDetails: '',
       loop: 'off',
-      shuffle: false
+      shuffle: false,
+      theaterMode: false
     }) as RootState,
   getters: {},
   actions: {

--- a/zimui/src/views/VideoPlayerView.vue
+++ b/zimui/src/views/VideoPlayerView.vue
@@ -226,56 +226,59 @@ watch(
 </script>
 
 <template>
-  <v-container v-if="video" :fluid="mdAndDown">
-    <v-row>
-      <v-spacer />
-      <v-col cols="12" md="7" lg="8" xl="6">
-        <!-- Video Player -->
-        <video-player
-          :options="videoOptions"
-          :loop="main.loop === LoopOptions.loopVideo"
-          :chapters-list="chapterList"
-          @video-ended="onVideoEnded"
-          @next-video="goToNextVideo"
-          @prev-video="goToPrevVideo"
+  <v-container v-if="video" :fluid="mdAndDown" :class="{'watch-theater-mode': main.theaterMode, 'watch-default-mode': !main.theaterMode && !smAndDown, 'watch-default-mode-smAndDown': !main.theaterMode && smAndDown}">
+    <!-- Video Player -->
+    <div class="video-player">
+      <video-player
+        :options="videoOptions"
+        :loop="main.loop === LoopOptions.loopVideo"
+        :chapters-list="chapterList"
+        @video-ended="onVideoEnded"
+        @next-video="goToNextVideo" 
+        @prev-video="goToPrevVideo"
         />
-        <!-- Playlist panel for mobile devices -->
-        <div v-if="smAndDown && playlist" class="mt-5">
-          <playlist-panel-preview
-            v-if="!showPlaylistPanel"
-            :playlist="playlist"
-            :current-video-index="currentVideoIndex"
-            @click="() => (showPlaylistPanel = !showPlaylistPanel)"
-          />
-          <playlist-panel
-            v-else
-            :playlist="playlist"
-            :video-slug="video_slug"
-            :playlist-slug="playlist_slug"
-            :current-video-index="currentVideoIndex"
-            :loop="main.loop"
-            :shuffle="main.shuffle"
-            :show-toggle="true"
-            @shuffle="() => main.setShuffle(!main.shuffle)"
-            @loop="cycleLoopOption"
-            @hide-panel="() => (showPlaylistPanel = false)"
-          />
-        </div>
-        <!-- Video Details -->
-        <div class="mt-5">
-          <video-title-info :title="video.title" :publication-date="video.publicationDate" />
-          <video-channel-info
-            :profile-path="video.author.profilePath || ''"
-            :channel-title="video.author.channelTitle || ''"
-            :channel-description="video.author.channelDescription || ''"
-            :joined-date="video.author.channelJoinedDate || ''"
-          />
-          <video-description :description="video.description" />
-        </div>
-      </v-col>
-      <!-- Playlist Panel -->
-      <v-col v-if="!smAndDown && playlist" cols="12" md="5" lg="4" xl="3">
+    </div>
+
+    <!-- Video Details & Mobile Playlist Panel -->
+    <div>
+      <!-- Playlist panel for mobile devices -->
+      <div v-if="smAndDown && playlist" class="mt-5">
+        <playlist-panel-preview
+          v-if="!showPlaylistPanel"
+          :playlist="playlist"
+          :current-video-index="currentVideoIndex"
+          @click="() => (showPlaylistPanel = !showPlaylistPanel)"
+        />
         <playlist-panel
+          v-else
+          :playlist="playlist"
+          :video-slug="video_slug"
+          :playlist-slug="playlist_slug"
+          :current-video-index="currentVideoIndex"
+          :loop="main.loop"
+          :shuffle="main.shuffle"
+          :show-toggle="true"
+          @shuffle="() => main.setShuffle(!main.shuffle)"
+          @loop="cycleLoopOption"
+          @hide-panel="() => (showPlaylistPanel = false)"
+        />
+      </div>
+      <!-- Video Details -->
+      <div class="mt-5">
+        <video-title-info :title="video.title" :publication-date="video.publicationDate" />
+        <video-channel-info
+          :profile-path="video.author.profilePath || ''"
+          :channel-title="video.author.channelTitle || ''"
+          :channel-description="video.author.channelDescription || ''"
+          :joined-date="video.author.channelJoinedDate || ''"
+        />
+        <video-description :description="video.description" />
+      </div>
+    </div>
+
+    <!-- Desktop Playlist Panel -->
+    <div v-if="!smAndDown" :class="['playlist-panel ml-5', main.theaterMode ? 'mt-5': '']">
+      <playlist-panel
           :playlist="playlist"
           :video-slug="video_slug"
           :playlist-slug="playlist_slug"
@@ -286,8 +289,6 @@ watch(
           @shuffle="() => main.setShuffle(!main.shuffle)"
           @loop="cycleLoopOption"
         />
-      </v-col>
-      <v-spacer />
-    </v-row>
+    </div>
   </v-container>
 </template>


### PR DESCRIPTION
Fix : #399 
- In case of watching videos on tablet and rotating screen, It'll be better than default and fullscreen modes.
- Also, If you're used to split tablet screen / laptop screen into two parts to open two programs at the same time. You would prefer to put video in theater mode (something between default and fullscreen).
- Use `t` keyboard shortcut to toggle.

![Screenshot from 2025-04-20 15-03-47](https://github.com/user-attachments/assets/4ad0ac54-4e6e-4451-8957-d38d2685eed1)
