### PR TITLE
skip reencoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Skip re-encoding downloaded videos with `--skip-reencoding` optional argument
+- Skip re-encoding downloaded videos with `--skip-reencoding` optional argument (#415)
 
 ## [3.4.1] - 2025-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Skip re-encoding downloaded videos with `--skip-reencoding` optional argument
+
 ## [3.4.1] - 2025-07-22
 
 ### Fixed

--- a/scraper/src/youtube2zim/entrypoint.py
+++ b/scraper/src/youtube2zim/entrypoint.py
@@ -203,9 +203,9 @@ def main():
     )
 
     parser.add_argument(
-        "--skip-reencode",
+        "--skip-reencoding",
         help="Skip reencoding downloaded videos, increasing disk usage.",
-        dest="skip_reencode", action="store_true", default=False
+        dest="skip_reencoding", action="store_true", default=False
     )
 
     args = parser.parse_args()

--- a/scraper/src/youtube2zim/entrypoint.py
+++ b/scraper/src/youtube2zim/entrypoint.py
@@ -204,7 +204,7 @@ def main():
 
     parser.add_argument(
         "--skip-reencoding",
-        help="Skip reencoding downloaded videos, increasing disk usage.",
+        help="Skip reencoding downloaded videos, keeping original quality at the expense of increased final ZIM size and potential codec issues.",
         dest="skip_reencoding", action="store_true", default=False
     )
 

--- a/scraper/src/youtube2zim/entrypoint.py
+++ b/scraper/src/youtube2zim/entrypoint.py
@@ -202,6 +202,12 @@ def main():
         dest="stats_filename",
     )
 
+    parser.add_argument(
+        "--skip-reencode",
+        help="Skip reencoding downloaded videos, increasing disk usage.",
+        dest="skip_reencode", action="store_true", default=False
+    )
+
     args = parser.parse_args()
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 

--- a/scraper/src/youtube2zim/processing.py
+++ b/scraper/src/youtube2zim/processing.py
@@ -34,11 +34,7 @@ def process_thumbnail(thumbnail_path: pathlib.Path, options: OptimizeWebpOptions
     optimize_webp(thumbnail_path, thumbnail_path, options)
 
 
-def post_process_video(video_dir, video_id, preset, video_format):
-    """apply custom post-processing to downloaded video
-
-    - resize thumbnail
-    - recompress video"""
+def find_video_in_dir(video_dir, video_id):
 
     # find downloaded video from video_dir
     files = [
@@ -56,7 +52,16 @@ def post_process_video(video_dir, video_id, preset, video_format):
             f"Multiple video file candidates for {video_id} in {video_dir}. "
             f"Picking {files[0]} out of {files}"
         )
-    src_path = files[0]
+
+    return files[0]
+
+def post_process_video(video_dir, video_id, preset, video_format):
+    """apply custom post-processing to downloaded video
+
+    - resize thumbnail
+    - recompress video"""
+
+    src_path = find_video_in_dir(video_dir, video_id)
 
     dst_path = src_path.with_name(f"video.{video_format}")
     logger.info(f"Reencode video to {dst_path}")

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -752,6 +752,7 @@ class Youtube2Zim:
                     video_location,
                     video_id
                 )
+                zim_path = f"videos/{video_id}/video.{video_path.suffix}"
             else:
                 post_process_video(
                     video_location,

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -752,7 +752,7 @@ class Youtube2Zim:
                     video_location,
                     video_id
                 )
-                zim_path = f"videos/{video_id}/video.{video_path.suffix}"
+                zim_path = f"videos/{video_id}/video{video_path.suffix}"
             else:
                 post_process_video(
                     video_location,

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -115,7 +115,7 @@ class Youtube2Zim:
         banner_image=None,
         main_color=None,
         secondary_color=None,
-        skip_reencode=False,
+        skip_reencoding=False,
     ):
         # data-retrieval info
         self.youtube_id = youtube_id
@@ -125,6 +125,7 @@ class Youtube2Zim:
         # video-encoding info
         self.video_format = video_format
         self.low_quality = low_quality
+        self.suceeded_zim_path = {}
 
         # options & zim params
         self.nb_videos_per_page = nb_videos_per_page
@@ -143,7 +144,7 @@ class Youtube2Zim:
         self.main_color = main_color
         self.secondary_color = secondary_color
         self.disable_metadata_checks = disable_metadata_checks
-        self.skip_reencode = skip_reencode
+        self.skip_reencoding = skip_reencoding
 
         metadata.APPLY_RECOMMENDATIONS = not self.disable_metadata_checks
 
@@ -722,6 +723,15 @@ class Youtube2Zim:
 
         s3_key = None
         if self.s3_storage:
+
+            '''
+            initial consideration: skip-reencoding wont play nice with s3_storage,
+            s3_storage usage assumes standardization (all videos haave same format)
+            which is not assured when skipping reencoding downloads (unimplemented),
+            to address this, ideally, a method should scan the remote folder to
+            find exactly what is the cached video format
+            '''
+
             s3_key = f"{self.video_format}/{self.video_quality}/{video_id}"
             logger.debug(
                 f"Attempting to download video file for {video_id} from cache..."
@@ -732,6 +742,7 @@ class Youtube2Zim:
                     video_path,
                     callback=Callback(delete_callback, args=(video_path,)),
                 )
+                self.suceeded_zim_path.update({video_id: zim_path})
                 return True
 
         try:
@@ -747,7 +758,7 @@ class Youtube2Zim:
             with yt_dlp.YoutubeDL(options_copy) as ydl:
                 ydl.download([video_id])
 
-            if self.skip_reencode:
+            if self.skip_reencoding:
                 video_path = find_video_in_dir(
                     video_location,
                     video_id
@@ -766,6 +777,7 @@ class Youtube2Zim:
                 video_path,
                 callback=Callback(delete_callback, args=(video_path,)),
             )
+            self.suceeded_zim_path.update({video_id: zim_path})
         except (
             yt_dlp.utils.DownloadError,
             FileNotFoundError,
@@ -1139,7 +1151,7 @@ class Youtube2Zim:
                     banner_path=f"channels/{author['channelId']}/banner.jpg",
                 ),
                 publication_date=video["contentDetails"]["videoPublishedAt"],
-                video_path=f"videos/{video_id}/video.{self.video_format}",
+                video_path=self.suceeded_zim_path[video_id],
                 thumbnail_path=get_thumbnail_path(video_id),
                 subtitle_path=f"videos/{video_id}" if len(subtitles_list) > 0 else None,
                 subtitle_list=subtitles_list,

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -47,7 +47,7 @@ from youtube2zim.constants import (
     YOUTUBE_LANG_MAP,
     logger,
 )
-from youtube2zim.processing import post_process_video, process_thumbnail
+from youtube2zim.processing import post_process_video, process_thumbnail, find_video_in_dir
 from youtube2zim.schemas import (
     Author,
     Channel,
@@ -115,6 +115,7 @@ class Youtube2Zim:
         banner_image=None,
         main_color=None,
         secondary_color=None,
+        skip_reencode=False,
     ):
         # data-retrieval info
         self.youtube_id = youtube_id
@@ -142,6 +143,7 @@ class Youtube2Zim:
         self.main_color = main_color
         self.secondary_color = secondary_color
         self.disable_metadata_checks = disable_metadata_checks
+        self.skip_reencode = skip_reencode
 
         metadata.APPLY_RECOMMENDATIONS = not self.disable_metadata_checks
 
@@ -744,12 +746,20 @@ class Youtube2Zim:
             )
             with yt_dlp.YoutubeDL(options_copy) as ydl:
                 ydl.download([video_id])
-            post_process_video(
-                video_location,
-                video_id,
-                preset,
-                self.video_format,
-            )
+
+            if self.skip_reencode:
+                video_path = find_video_in_dir(
+                    video_location,
+                    video_id
+                )
+            else:
+                post_process_video(
+                    video_location,
+                    video_id,
+                    preset,
+                    self.video_format,
+                )
+
             self.add_file_to_zim(
                 zim_path,
                 video_path,


### PR DESCRIPTION
requirement exposed in related #384, slow re-encoding downloaded videos could be helped by a) gpu acceleration or b) skipping reeconding, this changes add the optional argument `--skip-reenconde` to allow the latter 