### PR TITLE
Fix addition of deno to the path to be accessible from all shells

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ COPY scraper/pyproject.toml /src/scraper/
 COPY scraper/src/youtube2zim/__about__.py /src/scraper/src/youtube2zim/__about__.py
 
 # Install deno (required by yt-dlp)
-RUN curl -fsSL https://deno.land/install.sh | sh -s -- -y
+RUN curl -fsSL https://deno.land/install.sh | sh -s \
+  && ln -s /root/.deno/bin/deno /usr/local/bin/deno
 
 # Install Python dependencies
 RUN pip install --no-cache-dir /src/scraper


### PR DESCRIPTION
deno default way to add itself to the PATH works only for bash ; by default, container uses /bin/sh, and hence does not find deno.

Fixing it by manually linked binary to `/usr/local/bin`.