### PR TITLE
Add impersonation library as suggested by Youtube extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Skip re-encoding downloaded videos with `--skip-reencoding` optional argument (#415)
+- Upgrade to Python 3.14 (and dependencies) and Node.JS 24 (and dependencies) and Debian Trixie (#426)
+- Add `deno` dependency to fix yt-dlp requirement for Youtube (#418)
+- Add impersonation library (#428)
 
 ## [3.4.1] - 2025-07-22
 

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -9,7 +9,7 @@ description = "Make ZIM file from a Youtube channel, user or playlist(s)"
 readme = "../README.md"
 dependencies = [
   "python-slugify==8.0.4",
-  "yt-dlp[default]",            # youtube-dl should be updated as frequently as possible
+  "yt-dlp[default,curl_cffi]", # youtube-dl should be updated as frequently as possible
   "python-dateutil==2.9.0.post0",
   "jinja2==3.1.6",
   "zimscraperlib==5.3.0",


### PR DESCRIPTION
yt-dlp seems to now mandate one more dep on youtube extractor (from https://farm.openzim.org/pipeline/59e14045-7cfd-45da-adac-80011719a4ff/debug):

```
WARNING: The extractor specified to use impersonation for this download, but no impersonate target is available. If you encounter errors, then see  https://github.com/yt-dlp/yt-dlp#impersonation  for information on installing the required dependencies
```

This PR adds this new requirement.