### PR TITLE
feat: added total playlist duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added Total playlist duration in the Playlist view and Playlist panel. (#435)
+
 ## [3.5.0] - 2025-11-17
 
 ### Added

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "pydantic==2.12.4",
   "pyhumps==3.8.0",
   "schedule==1.2.2",
+  "isodate==0.7.2"
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 

--- a/scraper/src/youtube2zim/schemas.py
+++ b/scraper/src/youtube2zim/schemas.py
@@ -79,6 +79,7 @@ class Playlist(CamelModel):
     thumbnail_path: str | None = None
     videos: list[VideoPreview]
     videos_count: int
+    duration: str
 
 
 class PlaylistPreview(CamelModel):
@@ -90,6 +91,7 @@ class PlaylistPreview(CamelModel):
     thumbnail_path: str | None = None
     videos_count: int
     main_video_slug: str
+    duration: str
 
 
 class Playlists(CamelModel):

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -18,6 +18,7 @@ import tempfile
 from gettext import gettext as _
 from pathlib import Path
 
+import isodate
 import yt_dlp
 import yt_dlp.utils
 from kiwixstorage import KiwixStorage
@@ -1177,8 +1178,11 @@ class Youtube2Zim:
             channel_data = get_channel_json(playlist.creator_id)
             videos = get_videos_list(playlist)
             playlist_videos = [generate_video_preview_object(video) for video in videos]
-
+            playlist_duration = 0
             # add videos to ZIM index
+            for video in videos:
+                video_id = video["contentDetails"]["videoId"]
+                playlist_duration += videos_channels[video_id]["duration_seconds"]
             for idx, video_obj in enumerate(playlist_videos):
                 self.add_custom_item_to_zim_index(
                     video_obj.title,
@@ -1206,10 +1210,17 @@ class Youtube2Zim:
                 thumbnail_path=get_thumbnail_path(
                     videos[0]["contentDetails"]["videoId"]
                 ),
+                duration=isodate.duration_isoformat(
+                    datetime.timedelta(seconds=playlist_duration)
+                ),
             )
 
         def generate_playlist_preview_object(playlist) -> PlaylistPreview:
             videos = get_videos_list(playlist)
+            playlist_duration = 0
+            for video in videos:
+                video_id = video["contentDetails"]["videoId"]
+                playlist_duration += videos_channels[video_id]["duration_seconds"]
             return PlaylistPreview(
                 slug=get_playlist_slug(playlist),
                 id=playlist.playlist_id,
@@ -1219,6 +1230,9 @@ class Youtube2Zim:
                 ),
                 videos_count=len(videos),
                 main_video_slug=get_video_slug(videos[0]),
+                duration=isodate.duration_isoformat(
+                    datetime.timedelta(seconds=playlist_duration)
+                ),
             )
 
         def get_playlist_slug(playlist) -> str:

--- a/scraper/src/youtube2zim/youtube.py
+++ b/scraper/src/youtube2zim/youtube.py
@@ -3,6 +3,7 @@
 
 from http import HTTPStatus
 
+import isodate
 import requests
 from dateutil import parser as dt_parser
 from zimscraperlib.download import stream_file
@@ -264,12 +265,17 @@ def get_videos_authors_info(videos_ids):
             req.raise_for_status()
             videos_json = req.json()
             for item in videos_json["items"]:
+                duration_iso = item["contentDetails"]["duration"]
+                duration_seconds = int(
+                    isodate.parse_duration(duration_iso).total_seconds()
+                )
                 req_items.update(
                     {
                         item["id"]: {
                             "channelId": item["snippet"]["channelId"],
                             "channelTitle": item["snippet"]["channelTitle"],
-                            "duration": item["contentDetails"]["duration"],
+                            "duration": duration_iso,
+                            "duration_seconds": duration_seconds,
                         }
                     }
                 )

--- a/scraper/tests-integration/integration.py
+++ b/scraper/tests-integration/integration.py
@@ -102,6 +102,7 @@ def test_zim_playlists_file():
         "thumbnailPath",
         "videosCount",
         "mainVideoSlug",
+        "duration",
     }
 
 
@@ -132,6 +133,7 @@ def test_zim_home_playlists_file():
         "videosCount",
         "publicationDate",
         "videos",
+        "duration",
     }
     assert set(video_json["playlists"][0]["videos"][0].keys()) == {
         "slug",
@@ -170,6 +172,7 @@ def test_zim_individual_playlists_files():
             "videosCount",
             "publicationDate",
             "videos",
+            "duration",
         }
         assert set(content_json["videos"][0].keys()) == {
             "slug",

--- a/zimui/cypress/e2e/playlist_view_page.cy.ts
+++ b/zimui/cypress/e2e/playlist_view_page.cy.ts
@@ -17,7 +17,11 @@ describe('playlist view', () => {
     cy.contains('.playlist-title', 'Timelapses').should('be.visible')
     cy.contains('.playlist-channel', 'openZIM_testing').should('be.visible')
     cy.contains('.playlist-description', 'A playlist of timelapse videos.').should('be.visible')
-    cy.contains('.playlist-info', '2 videos | Jun 4, 2024').should('be.visible')
+    cy.get('.playlist-info').within(() => {
+      cy.contains('2 videos').should('be.visible')
+      cy.contains('Published on Jun 4, 2024').should('be.visible')
+      cy.contains('Total Duration:').should('be.visible')
+    })
 
     cy.contains('.v-card-title', 'Timelapse').should('be.visible')
     cy.contains('.v-card-title', 'Cloudy Sky Time Lapse').should('be.visible')

--- a/zimui/cypress/fixtures/channel/home_playlists.json
+++ b/zimui/cypress/fixtures/channel/home_playlists.json
@@ -31,7 +31,8 @@
           "duration": "PT11S"
         }
       ],
-      "videosCount": 2
+      "videosCount": 2,
+      "duration": "PT20S"
     },
     {
       "id": "PLMK6hZr9PcshJpNSRVaKReGlwhVlh5Gph",
@@ -57,7 +58,8 @@
           "duration": "PT2M27S"
         }
       ],
-      "videosCount": 1
+      "videosCount": 1,
+      "duration": "PT2M27S"
     },
     {
       "id": "PLMK6hZr9PcsjcF5mnaQk8Fi-xnb0AQgGI",
@@ -90,7 +92,8 @@
           "duration": "PT36S"
         }
       ],
-      "videosCount": 2
+      "videosCount": 2,
+      "duration": "PT47S"
     },
     {
       "id": "PLMK6hZr9PcsjTJ5u2z-khzvDNXlqdO2wS",
@@ -116,7 +119,8 @@
           "duration": "PT9S"
         }
       ],
-      "videosCount": 1
+      "videosCount": 1,
+      "duration": "PT9S"
     }
   ]
 }

--- a/zimui/cypress/fixtures/channel/playlists.json
+++ b/zimui/cypress/fixtures/channel/playlists.json
@@ -6,7 +6,8 @@
       "title": "Timelapses",
       "thumbnailPath": "videos/9TgosbGRsTk/video.webp",
       "videosCount": 2,
-      "mainVideoSlug": "timelapse-9Tgo"
+      "mainVideoSlug": "timelapse-9Tgo",
+      "duration": "PT47S"
     },
     {
       "slug": "trailers-5Gph",
@@ -14,7 +15,8 @@
       "title": "Trailers",
       "thumbnailPath": "videos/TcMBFSGVi1c/video.webp",
       "videosCount": 1,
-      "mainVideoSlug": "marvel_studios_avengers_endgame_official_trailer-TcMB"
+      "mainVideoSlug": "marvel_studios_avengers_endgame_official_trailer-TcMB",
+      "duration": "PT2M27S"
     },
     {
       "slug": "coffee-O2wS",
@@ -22,7 +24,8 @@
       "title": "Coffee",
       "thumbnailPath": "videos/DYvYGQHYScc/video.webp",
       "videosCount": 1,
-      "mainVideoSlug": "coffee_machine-DYvY"
+      "mainVideoSlug": "coffee_machine-DYvY",
+      "duration": "PT9S"
     }
   ]
 }

--- a/zimui/cypress/fixtures/channel/playlists/timelapses-QgGI.json
+++ b/zimui/cypress/fixtures/channel/playlists/timelapses-QgGI.json
@@ -28,5 +28,6 @@
       "duration": "PT36S"
     }
   ],
-  "videosCount": 2
+  "videosCount": 2,
+  "duration": "PT47S"
 }

--- a/zimui/cypress/fixtures/channel/playlists/uploads_from_openzim_testing-917Q.json
+++ b/zimui/cypress/fixtures/channel/playlists/uploads_from_openzim_testing-917Q.json
@@ -26,5 +26,6 @@
       "duration": "PT11S"
     }
   ],
-  "videosCount": 2
+  "videosCount": 2,
+  "duration": "PT20S"
 }

--- a/zimui/src/components/playlist/panel/PlaylistPanel.vue
+++ b/zimui/src/components/playlist/panel/PlaylistPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
 import { useDisplay } from 'vuetify'
+import { formatTimestamp } from '@/utils/format-utils'
 
 import type { Playlist } from '@/types/Playlists'
 import { LoopOptions } from '@/types/Playlists'
@@ -90,6 +91,9 @@ const load = async ({ done }: { done: (status: 'ok' | 'empty') => void }) => {
               {{ props.playlist.author.channelTitle }}
             </span>
             - {{ props.currentVideoIndex + 1 }}/{{ props.playlist.videos.length }}
+          </v-card-subtitle>
+          <v-card-subtitle class="panel-channel text-caption">
+            Total Duration: {{ formatTimestamp(props.playlist.duration) }}
           </v-card-subtitle>
         </v-col>
         <v-col v-if="showToggle" cols="3" class="d-flex align-center justify-end">

--- a/zimui/src/types/Playlists.ts
+++ b/zimui/src/types/Playlists.ts
@@ -11,6 +11,7 @@ export interface Playlist {
   thumbnailPath?: string
   videos: VideoPreview[]
   videosCount: number
+  duration: string
 }
 export interface PlaylistPreview {
   slug: string

--- a/zimui/src/views/PlaylistView.vue
+++ b/zimui/src/views/PlaylistView.vue
@@ -5,7 +5,7 @@ import { useMainStore } from '@/stores/main'
 import { useRoute, useRouter } from 'vue-router'
 
 import type { Playlist } from '@/types/Playlists'
-import { formatDate } from '@/utils/format-utils'
+import { formatDate, formatTimestamp } from '@/utils/format-utils'
 
 import PlaylistPanelItem from '@/components/playlist/panel/PlaylistPanelItem.vue'
 import thumbnailPlaceholder from '@/assets/images/thumbnail-placeholder.jpg'
@@ -101,9 +101,16 @@ watch(
           <p class="playlist-channel text-body-1 font-weight-medium mt-2">
             {{ playlist.author.channelTitle }}
           </p>
-          <p class="playlist-info text-caption mt-1">
-            <v-icon>mdi-video-outline</v-icon> {{ playlist.videosCount }} videos |
-            {{ formatDate(playlist.publicationDate) }}
+          <p class="playlist-info text-caption mt-1 d-flex flex-column">
+            <span>
+              <v-icon>mdi-video-outline</v-icon> {{ playlist.videosCount }} videos
+            </span>
+            <span>
+              Published on {{ formatDate(playlist.publicationDate) }}
+            </span>
+            <span>
+              <v-icon>mdi-clock-outline</v-icon> Total Duration: {{ formatTimestamp(playlist.duration) }}
+            </span>
           </p>
           <div class="mt-6 d-flex align-center justify-center">
             <v-btn


### PR DESCRIPTION
Added Playlist duration;
- Used `video_channels` to store duration of each video in seconds, used an aggregator and added it to the schema of the playlist.
- Displayed that view in the `PlaylistView` component and `PlaylistPanel` component.

I have modified the testcases in the `integration_tests` and have locally tested. All test cases were passed

Please see the screenshots of the modification in UI for your reference
<img width="1900" height="920" alt="youtube_zim_ss1" src="https://github.com/user-attachments/assets/fec69f26-5e2c-4063-8a7a-263b2fe58f52" />
<img width="1900" height="920" alt="youtube_zim_ss2" src="https://github.com/user-attachments/assets/d79380c0-05da-4b32-87c6-c3298a468379" />
<img width="1900" height="920" alt="youtube_zim_ss3" src="https://github.com/user-attachments/assets/6c446842-0881-4e45-8840-28c8d4a8e94c" />
