### PR TITLE
fix(navigation): resolve home tab underbar not updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolve home tab underbar not updating (#448)
+
 ### Added
 
 - Implement dark mode (#424)

--- a/zimui/src/components/channel/ChannelHeader.vue
+++ b/zimui/src/components/channel/ChannelHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useDisplay } from 'vuetify'
 
 import AboutDialogButton from '@/components/channel/AboutDialogButton.vue'
@@ -42,8 +42,6 @@ const tabs = computed(() => {
 
 // Hide tabs if there is only one playlist
 const hideTabs = computed(() => main.channel?.playlistCount === 1)
-
-const tab = ref<number>(tabs.value[0]?.id || 0)
 </script>
 
 <template>
@@ -87,8 +85,8 @@ const tab = ref<number>(tabs.value[0]?.id || 0)
       </v-container>
 
       <!-- Tabs Navigation -->
-      <v-tabs v-if="!hideTabs" v-model="tab" align-tabs="center">
-        <v-tab v-for="item in tabs" :key="item.id" :to="item.to">
+      <v-tabs v-if="!hideTabs" align-tabs="center">
+        <v-tab v-for="item in tabs" :key="item.id" :to="item.to" exact>
           {{ item.title }}
         </v-tab>
       </v-tabs>

--- a/zimui/src/router/index.ts
+++ b/zimui/src/router/index.ts
@@ -16,13 +16,11 @@ const router = createRouter({
   routes: [
     {
       path: '/',
-      name: 'home',
       component: HomeView,
-      redirect: '/channel-home',
       children: [
         {
-          path: 'channel-home',
-          name: 'channel-home',
+          path: '',
+          name: 'home',
           component: ChannelHomeTab
         },
         {


### PR DESCRIPTION
Fix: #448 

**What does this PR do?**
Resolves a UI bug where the Vuetify tab slider (underbar) failed to slide back to the "Home" tab when a user navigated back from other tabs like "Videos" or "Shorts".

**Changes included**:
1. Cleaned up `<v-tabs>` template in `ChannelHomeTab.vue` (removed `v-model` and `<router-link>` wrappers).
2. Added `exact` attribute to the `v-tab` loop.
3. Updated `router/index.ts` to assign name: `'home'` to the specific child route (`path: ' '`) rather than the parent route.