### PR TITLE
Fix: Resolve Cypress E2E crash and prevent premature PlaylistPanel rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Resolve home tab underbar not updating (#448)
+- Resolve Cypress E2E crash and prevent premature PlaylistPanel rendering (#450)
 
 ### Added
 

--- a/zimui/src/components/playlist/panel/PlaylistPanel.vue
+++ b/zimui/src/components/playlist/panel/PlaylistPanel.vue
@@ -21,8 +21,6 @@ const props = defineProps<{
   shuffle: boolean
 }>()
 
-const isLoading = computed(() => props.playlist.videos === undefined)
-
 const windowHeight = ref(
   window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight
 )
@@ -78,10 +76,7 @@ const load = async ({ done }: { done: (status: 'ok' | 'empty') => void }) => {
 </script>
 
 <template>
-  <div v-if="isLoading" class="container mt-8 d-flex justify-center">
-    <v-progress-circular class="d-inline" indeterminate></v-progress-circular>
-  </div>
-  <v-card v-else class="border-thin rounded-lg" flat>
+  <v-card class="border-thin rounded-lg" flat>
     <v-card-item class="border-b-thin px-2">
       <v-row class="px-2">
         <v-col :cols="showToggle ? 9 : 12">

--- a/zimui/src/views/VideoPlayerView.vue
+++ b/zimui/src/views/VideoPlayerView.vue
@@ -287,7 +287,10 @@ watch(
     </div>
 
     <!-- Desktop Playlist Panel -->
-    <div v-if="!smAndDown" :class="['playlist-panel ml-5', main.theaterMode ? 'mt-5' : '']">
+    <div
+      v-if="!smAndDown && playlist"
+      :class="['playlist-panel ml-5', main.theaterMode ? 'mt-5' : '']"
+    >
       <playlist-panel
         :playlist="playlist"
         :video-slug="video_slug"


### PR DESCRIPTION
Fix: #450
This PR fixes the intermittent E2E test failures in `video_player_page.cy.ts` by enforcing strict conditional rendering in the parent component (`VideoPlayerView.vue`).