### PR TITLE
Fix Pattern Error for invalid regex group reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Resolve home tab underbar not updating (#448)
 - Resolve Cypress E2E crash and prevent premature PlaylistPanel rendering (#450)
+- Resolve re.PatternError for invalid regex group reference (#434)
 
 ### Added
 

--- a/scraper/src/youtube2zim/scraper.py
+++ b/scraper/src/youtube2zim/scraper.py
@@ -426,8 +426,8 @@ class Youtube2Zim:
                 index_html_path = self.zimui_dist / path
                 html_content = index_html_path.read_text(encoding="utf-8")
                 new_html_content = re.sub(
-                    r"(<title>)(.*?)(</title>)",
-                    rf"\1{self.title}\3",
+                    r"<title>.*?</title>",
+                    f"<title>{self.title}</title>",
                     html_content,
                     flags=re.IGNORECASE,
                 )


### PR DESCRIPTION
Fixes #434 

The scraper would throw a _re.PatternError_ if the channel/playlist name begins with a digit, especially on Python 3.14. This fix ensures the scraper runs smoothly on Python 3.14 regardless of the title.