### PR TITLE
Bundle Zim UI inside the pip package

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -13,6 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Set up Node js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: zimui/.node-version
+
+      - name: Build zimui
+        working-directory: zimui
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -96,6 +96,9 @@ jobs:
         run: |
           docker build -t youtube2zim .
 
+      - name: Ensure zimui and its files are present in Docker image
+        run: docker run --rm youtube2zim python -c "from pathlib import Path; import youtube2zim; path = Path(youtube2zim.__file__).parent / 'zimui'; assert (path / 'index.html').is_file() and (path / 'assets').is_dir(), 'zimui not found'"
+
       - name: Run scraper
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -365,14 +365,8 @@ pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,macos,python,database,visualstudiocode,intellij
 
-# JS deps
-scraper/src/youtube2zim/templates/assets/chosen/
-scraper/src/youtube2zim/templates/assets/jquery.min.js
-scraper/src/youtube2zim/templates/assets/ogvjs/
-scraper/src/youtube2zim/templates/assets/videojs-ogvjs.js
-scraper/src/youtube2zim/templates/assets/videojs/
-scraper/src/youtube2zim/templates/assets/polyfills.js
-scraper/src/youtube2zim/templates/assets/webp-hero.bundle.js
+# Zimui build dist
+scraper/src/youtube2zim/zimui/
 
 # output dir
 output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement dark mode (#424)
 - Added Total playlist duration in the Playlist view and Playlist panel. (#435)
 - Added `analyze_zim.py` contrib script to analyze video duration vs. file size correlation in ZIM files (#439)
+- Bundle ZIM UI inside pip package (#459)
 
 ## [3.5.0] - 2025-11-17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:24-alpine as zimui
 
 WORKDIR /src
-COPY zimui /src
-RUN yarn install --frozen-lockfile
-RUN yarn build
+COPY . /src
+RUN cd zimui && yarn install --frozen-lockfile
+RUN cd zimui && yarn build
 
 FROM python:3.14-trixie
 LABEL org.opencontainers.image.source https://github.com/openzim/youtube
@@ -37,17 +37,17 @@ RUN curl -fsSL https://deno.land/install.sh | sh -s \
 # Install Python dependencies
 RUN pip install --no-cache-dir /src/scraper
 
-# Copy code + associated artifacts
+# Copy code
 COPY scraper/src /src/scraper/src
+
+# Copy zimui build output
+COPY --from=zimui /src/scraper/src/youtube2zim/zimui /src/scraper/src/youtube2zim/zimui
+
+# Copy associated artifacts
 COPY *.md LICENSE CHANGELOG.md /src/
 
 # Install + cleanup
 RUN pip install --no-cache-dir /src/scraper \
  && rm -rf /src/scraper
-
-# Copy zimui build output
-COPY --from=zimui /src/dist /src/zimui
-
-ENV YOUTUBE_ZIMUI_DIST=/src/zimui
 
 CMD ["youtube2zim", "--help"]

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -57,9 +57,6 @@ exclude = ["/.github"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/youtube2zim"]
-artifacts = [
-  "src/youtube2zim/templates/assets/**",
-]
 
 [tool.hatch.envs.default]
 features = ["dev"]
@@ -98,7 +95,7 @@ all = "inv checkall --args '{args}'"
 [tool.black]
 line-length = 88
 target-version = ['py314']
-exclude = "(src/youtube2zim/templates/.*|.hatch/.*)"
+exclude = "(src/youtube2zim/zimui/.*|.hatch/.*)"
 
 [tool.ruff]
 target-version = "py314"
@@ -221,7 +218,7 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.pyright]
 include = ["src", "tests", "tasks.py"]
-exclude = [".env/**", ".venv/**", "src/youtube2zim/templates", ".hatch"]
+exclude = [".env/**", ".venv/**", "src/youtube2zim/zimui", ".hatch"]
 extraPaths = ["src"]
 pythonVersion = "3.14"
 typeCheckingMode = "basic"

--- a/scraper/src/youtube2zim/entrypoint.py
+++ b/scraper/src/youtube2zim/entrypoint.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 import os
 import sys
+from pathlib import Path
 
 from youtube2zim.constants import NAME, SCRAPER, logger
 from youtube2zim.scraper import Youtube2Zim
@@ -79,7 +80,10 @@ def main():
         help=(
             "Directory containing Vite build output from the Zim UI Vue.JS application"
         ),
-        default=os.getenv("YOUTUBE_ZIMUI_DIST", "../zimui/dist"),
+        default=os.getenv(
+            "YOUTUBE_ZIMUI_DIST",
+            str(Path(__file__).parent / "zimui"),
+        ),
     )
 
     parser.add_argument(

--- a/zimui/vite.config.ts
+++ b/zimui/vite.config.ts
@@ -35,5 +35,9 @@ export default defineConfig({
   },
   preview: {
     port: 5173
+  },
+  build: {
+    outDir: '../scraper/src/youtube2zim/zimui',
+    emptyOutDir: true,
   }
 })


### PR DESCRIPTION
Fixes #459 

This approach builds the Zim UI, copies the compiled files into the scraper's  `/templates/dist/` directory, and bundles them with the pip package.