### PR TITLE
feat:add linux/arm64 support to Docker image

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -49,6 +49,7 @@ jobs:
           latest-on-tag: true
           restrict-to: openzim/youtube
           registries: ghcr.io
+          platforms: linux/amd64 linux/arm64
           credentials:
             GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
             GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/PublishDockerDevImage.yaml
+++ b/.github/workflows/PublishDockerDevImage.yaml
@@ -25,3 +25,4 @@ jobs:
             GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}
           repo_description: auto
           repo_overview: auto
+          platforms: linux/amd64 linux/arm64

--- a/.github/workflows/QA.yml
+++ b/.github/workflows/QA.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  check-scraper-qa:
+  check-scraper-qa-amd64:
     runs-on: ubuntu-24.04
 
     steps:
@@ -37,8 +37,61 @@ jobs:
         working-directory: scraper
         run: inv check-pyright
 
-  check-zimui-qa:
+  check-scraper-qa-arm64:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: scraper/pyproject.toml
+
+      - name: Install dependencies
+        working-directory: scraper
+        run: |
+          pip install -U pip
+          pip install -e .[lint,check,scripts,test]
+
+      - name: Check black formatting
+        working-directory: scraper
+        run: inv lint-black
+
+      - name: Check ruff
+        working-directory: scraper
+        run: inv lint-ruff
+
+      - name: Check pyright
+        working-directory: scraper
+        run: inv check-pyright
+
+  check-zimui-qa-amd64:
     runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: zimui/.node-version
+
+      - name: Install JS dependencies
+        working-directory: zimui
+        run: |
+          yarn install
+      - name: Check prettier
+        working-directory: zimui
+        run: |
+          yarn format-check
+      - name: Check eslint
+        working-directory: zimui
+        run: |
+          yarn lint-check
+
+  check-zimui-qa-arm64:
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  test-scraper:
+  test-scraper-amd64:
     runs-on: ubuntu-24.04
 
     steps:
@@ -35,7 +35,35 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  build-scraper:
+  test-scraper-arm64:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: scraper/pyproject.toml
+
+      - name: Install dependencies (and project)
+        working-directory: scraper
+        run: |
+          pip install -U pip
+          pip install -e .[test,scripts]
+
+      - name: Run the tests
+        working-directory: scraper
+        run: inv coverage --args "-vvv"
+
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+
+  build-scraper-amd64:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -52,7 +80,23 @@ jobs:
           pip install -U pip build
           python3 -m build --sdist --wheel
 
-  build-and-test-zimui:
+  build-scraper-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: scraper/pyproject.toml
+
+      - name: Ensure we can build Python targets
+        working-directory: scraper
+        run: |
+          pip install -U pip build
+          python3 -m build --sdist --wheel
+
+  build-and-test-zimui-amd64:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -86,8 +130,42 @@ jobs:
           cd zimui
           $(yarn bin)/cypress run
 
+  build-and-test-zimui-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: zimui/.node-version
+
+      - name: Install dependencies
+        working-directory: zimui
+        run: |
+          yarn install
+
+      - name: Build
+        working-directory: zimui
+        run: |
+          yarn build
+
+      - name: Start web server
+        working-directory: zimui
+        run: |
+          yarn preview &
+
+      - name: Wait for web server to be ready
+        run: |
+          npx wait-on http://localhost:5173
+
+      - name: Run frontend tests
+        run: |
+          cd zimui
+          $(yarn bin)/cypress run
+
   # this job replaces the standard "build_docker" job since it builds the docker image
-  run-integration-tests:
+  run-integration-tests-amd64:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -107,3 +185,26 @@ jobs:
 
       - name: Run integration test suite
         run: docker run -v $PWD/scraper/tests-integration/integration.py:/src/scraper/tests-integration/integration.py -v $PWD/output:/output youtube2zim bash -c "pip install pytest; pytest -v /src/scraper/tests-integration/integration.py"
+
+
+  run-integration-tests-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Ensure we can build the Docker image
+        run: |
+          docker build -t youtube2zim .
+
+      - name: Ensure zimui and its files are present in Docker image
+        run: docker run --rm youtube2zim python -c "from pathlib import Path; import youtube2zim; path = Path(youtube2zim.__file__).parent / 'zimui'; assert (path / 'index.html').is_file() and (path / 'assets').is_dir(), 'zimui not found'"
+
+      - name: Run scraper
+        env:
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          OPTIMIZATION_CACHE_URL: ${{ secrets.OPTIMIZATION_CACHE_URL }}
+        run: docker run -v $PWD/output:/output youtube2zim youtube2zim --api-key "$YOUTUBE_API_KEY" --optimization-cache "$OPTIMIZATION_CACHE_URL" --id "UC8elThf5TGMpQfQc_VE917Q" --name "tests_en_openzim-testing" --zim-file "openZIM_testing.zim" --tags "tEsTing,x-mark:yes"
+
+      - name: Run integration test suite
+        run: docker run -v $PWD/scraper/tests-integration/integration.py:/src/scraper/tests-integration/integration.py -v $PWD/output:/output youtube2zim bash -c "pip install pytest; pytest -v /src/scraper/tests-integration/integration.py"
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Total playlist duration in the Playlist view and Playlist panel. (#435)
 - Added `analyze_zim.py` contrib script to analyze video duration vs. file size correlation in ZIM files (#439)
 - Bundle ZIM UI inside pip package (#459)
+- Added `linux/arm64` support to Docker image and CI (#458)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For more details / advanced usage than what is in this README, see the [Manual](
 # Prerequisites
 
 - [Docker](https://docs.docker.com/engine/install/)
-- amd64 architecture
+- amd64 or arm64 architecture
 
 # Installation
 


### PR DESCRIPTION
## Issue

When pulling the Docker image on an `arm64` machine,
users get an `exec format error` because only a `linux/amd64` image is published
to the registry. ARM64 users cannot run the tool at all.

## Test

Tested ARM64 support locally using `docker buildx`:

- Built the image successfully for `linux/arm64`
- Ran the container with a real scrape (`@veritasium`, `--pagination=1`, `--low-quality`)
- Video downloaded, formats merged, and re-encoding started without any architecture errors

All Dockerfile components confirmed ARM64 compatible:
- `node:24-alpine`, `python:3.14-trixie` — multi-arch base images
- `ffmpeg`, `wget`, `aria2` — available on arm64 via apt
- `deno` — official arm64 support via install script

Closes #458