### PR TITLE
rename length constraints to graphemes

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -51,24 +51,24 @@
       "required": false,
       "title": "ZIM Title",
       "description": "Custom title for your ZIM. Default to Channel name (of first video if playlists)",
-      "minLength": 1,
-      "maxLength": 30
+      "minGraphemes": 1,
+      "maxGraphemes": 30
     },
     "description": {
       "type": "string",
       "required": false,
       "title": "ZIM Description",
       "description": "Description (up to 80 chars) for ZIM",
-      "minLength": 1,
-      "maxLength": 80
+      "minGraphemes": 1,
+      "maxGraphemes": 80
     },
     "long_description": {
       "type": "string",
       "required": false,
       "title": "ZIM Long Description",
       "description": "Long description (up to 4000 chars) for ZIM",
-      "minLength": 1,
-      "maxLength": 4000
+      "minGraphemes": 1,
+      "maxGraphemes": 4000
     },
     "creator": {
       "type": "string",


### PR DESCRIPTION
## Changes
- rename length constraints to end with graphemes (See openzim/zimfarm#1890)